### PR TITLE
Improve POSIX compatibility of build script

### DIFF
--- a/build_rte_rrtmgp.sh
+++ b/build_rte_rrtmgp.sh
@@ -1,6 +1,8 @@
-# /bin/bash
+#!/bin/sh
 
-if [ -n "$CONDA_PREFIX" ] && [ "$OS" == *"Windows"* ] || [ -z "$CONDA_PREFIX" ]; then
+if [ -n "$CONDA_PREFIX" ] && [ "$OS" = *"Windows"* ]; then
+    export FC=gfortran
+elif [ -z "$CONDA_PREFIX" ]; then
     export FC=gfortran
 fi
 


### PR DESCRIPTION
Our current build script is not fully POSIX compatible, which leads to syntax issues when running on Ubuntu (related to how the if condition is structured, specifically with the combination of && (AND) and || (OR) operators without proper grouping, I believe).

This PR updates the logic to work better across systems while maintaining the same functionality.