### PR TITLE
update DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI passing](https://github.com/earth-system-radiation/pyRTE-RRTMGP/actions/workflows/conda.yml/badge.svg)](https://github.com/earth-system-radiation/pyRTE-RRTMGP/actions/workflows/conda.yml)
 [![Documentation Status](https://readthedocs.org/projects/pyrte-rrtmgp/badge/?version=latest)](https://pyrte-rrtmgp.readthedocs.io/en/latest/?badge=latest)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10982461.svg)](https://doi.org/10.5281/zenodo.10982461)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10982460.svg)](https://doi.org/10.5281/zenodo.10982460)
 
 # pyRTE-RRTMGP
 


### PR DESCRIPTION
Update the DOI badge in the README to point to the "all version" DOI (instead of the version-specific one)