### PR TITLE
Large-scale cloud optics example

### DIFF
--- a/examples/cloud_optics_example.py
+++ b/examples/cloud_optics_example.py
@@ -1,0 +1,32 @@
+#! /usr/env/python 
+import xarray as xr
+import scipy as sc
+
+#
+# Compute cloud optics for a large sample of clouds 
+#   fetch-DYAMOND-data.py must be run first. 
+#
+
+#
+# Only about half the levels contain clouds so for cloud optics only we can limit the data we import
+#
+min_lev_liquid = 107 # There are almost no liquid clouds in levels higher (smaller index is higher) than 107
+min_lev_ice = 78 # There are almost no ice clouds in levels higher (smaller index is higher) than 78
+
+atmosphere= xr.open_mfdataset(
+	"GEOS-DYAMOND2-data/*.nc4", 
+	drop_variables=["anchor", "cubed_sphere", "orientation", "contacts", "corner_lats", "corner_lons"]
+).isel(lev=slice(min_lev_ice,))
+#
+# By default the dask arrays are contiguous in Xdim and Ydim
+#   This will work for computing optics but not for computing fluxes, 
+#   where chunks need to include all layers
+#
+
+atmosphere["LWP"] = (atmosphere.DELP * atmosphere.QL) / sc.constants.g
+atmosphere["IWP"] = (atmosphere.DELP * atmosphere.QI) / sc.constants.g
+
+#
+# What we'd eventutally like to do... 
+#
+clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)

--- a/examples/cloud_optics_example.py
+++ b/examples/cloud_optics_example.py
@@ -1,25 +1,36 @@
-#! /usr/env/python 
-import xarray as xr
+#! /usr/env/python
 import scipy as sc
+import xarray as xr
 
 #
-# Compute cloud optics for a large sample of clouds 
-#   fetch-DYAMOND-data.py must be run first. 
+# Compute cloud optics for a large sample of clouds
+#   fetch-DYAMOND-data.py must be run first.
 #
 
 #
 # Only about half the levels contain clouds so for cloud optics only we can limit the data we import
 #
-min_lev_liquid = 107 # There are almost no liquid clouds in levels higher (smaller index is higher) than 107
-min_lev_ice = 78 # There are almost no ice clouds in levels higher (smaller index is higher) than 78
+min_lev_liquid = 107  # There are almost no liquid clouds in levels higher (smaller index is higher) than 107
+min_lev_ice = 78  # There are almost no ice clouds in levels higher (smaller index is higher) than 78
 
-atmosphere= xr.open_mfdataset(
-	"GEOS-DYAMOND2-data/*.nc4", 
-	drop_variables=["anchor", "cubed_sphere", "orientation", "contacts", "corner_lats", "corner_lons"]
-).isel(lev=slice(min_lev_ice,))
+atmosphere = xr.open_mfdataset(
+    "GEOS-DYAMOND2-data/*.nc4",
+    drop_variables=[
+        "anchor",
+        "cubed_sphere",
+        "orientation",
+        "contacts",
+        "corner_lats",
+        "corner_lons",
+    ],
+).isel(
+    lev=slice(
+        min_lev_ice,
+    )
+)
 #
 # By default the dask arrays are contiguous in Xdim and Ydim
-#   This will work for computing optics but not for computing fluxes, 
+#   This will work for computing optics but not for computing fluxes,
 #   where chunks need to include all layers
 #
 
@@ -27,6 +38,6 @@ atmosphere["LWP"] = (atmosphere.DELP * atmosphere.QL) / sc.constants.g
 atmosphere["IWP"] = (atmosphere.DELP * atmosphere.QI) / sc.constants.g
 
 #
-# What we'd eventutally like to do... 
+# What we'd eventutally like to do...
 #
 clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)

--- a/examples/cloud_optics_example.py
+++ b/examples/cloud_optics_example.py
@@ -16,7 +16,7 @@ min_lev_ice = 78
 # There are almost no ice clouds in levels higher (smaller index is higher) than 78
 
 atmosphere = xr.open_mfdataset(
-    "GEOS-DYAMOND2-data/*.nc4",
+    "GEOS-DYAMOND2-data/*inst_01hr_3d_*.nc4",
     drop_variables=[
         "anchor",
         "cubed_sphere",

--- a/examples/cloud_optics_example.py
+++ b/examples/cloud_optics_example.py
@@ -1,17 +1,19 @@
 #! /usr/env/python
+"""Compute cloud optics for a large sample of clouds."""
+#
+#   fetch-DYAMOND-data.py must be run first.
+#
 import scipy as sc
 import xarray as xr
 
 #
-# Compute cloud optics for a large sample of clouds
-#   fetch-DYAMOND-data.py must be run first.
+# Only about half the levels contain clouds so
+#   for cloud optics only we can limit the data we import
 #
-
-#
-# Only about half the levels contain clouds so for cloud optics only we can limit the data we import
-#
-min_lev_liquid = 107  # There are almost no liquid clouds in levels higher (smaller index is higher) than 107
-min_lev_ice = 78  # There are almost no ice clouds in levels higher (smaller index is higher) than 78
+min_lev_liquid = 107
+# There are almost no liquid clouds in levels higher (smaller index is higher) than 107
+min_lev_ice = 78
+# There are almost no ice clouds in levels higher (smaller index is higher) than 78
 
 atmosphere = xr.open_mfdataset(
     "GEOS-DYAMOND2-data/*.nc4",

--- a/examples/cloud_optics_example.py
+++ b/examples/cloud_optics_example.py
@@ -31,9 +31,9 @@ atmosphere = xr.open_mfdataset(
     )
 )
 #
-# By default the dask arrays are contiguous in Xdim and Ydim
+# By default the dask arrays are contiguous in Xdim and Ydim (first two dimensions)
 #   This will work for computing optics but not for computing fluxes,
-#   where chunks need to include all layers
+#   where chunks need to include all layers/levels
 #
 
 atmosphere["LWP"] = (atmosphere.DELP * atmosphere.QL) / sc.constants.g
@@ -42,4 +42,4 @@ atmosphere["IWP"] = (atmosphere.DELP * atmosphere.QI) / sc.constants.g
 #
 # What we'd eventutally like to do...
 #
-clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)
+# clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)

--- a/examples/create-virtual-zaar.py
+++ b/examples/create-virtual-zaar.py
@@ -1,25 +1,31 @@
 #! /usr/env/python
-"""Write a virtual Zaar with icechunk """
+"""Write a virtual Zaar with icechunk"""
 
 import glob
+
+import icechunk
 import xarray as xr
 from virtualizarr import open_virtual_dataset
-import icechunk
 
-# could replace with URLs 
+# could replace with URLs
 paths = glob.glob("GEOS-DYAMOND2-data/DYAMONDv2_c2880_L181.inst_01hr_3d_*.nc4")
 
-all = xr.merge([
-	open_virtual_dataset(p, 
-		drop_variables=[
-		        "anchor",
-		        "cubed_sphere",
-		        "orientation",
-		        "contacts",
-		        "corner_lats",
-		        "corner_lons",
-		    ],) for p in paths], 
-  compat="override", 
+all = xr.merge(
+    [
+        open_virtual_dataset(
+            p,
+            drop_variables=[
+                "anchor",
+                "cubed_sphere",
+                "orientation",
+                "contacts",
+                "corner_lats",
+                "corner_lons",
+            ],
+        )
+        for p in paths
+    ],
+    compat="override",
 )
 
 storage = icechunk.local_filesystem_storage("./local/icechunk/store")
@@ -28,7 +34,7 @@ session = repo.writable_session("main")
 
 all.virtualize.to_icechunk(session.store)
 session.commit("Wrote first dataset")
-session.close() 
+session.close()
 
 ds = xr.open_zarr(
     session.store,

--- a/examples/create-virtual-zaar.py
+++ b/examples/create-virtual-zaar.py
@@ -1,0 +1,38 @@
+#! /usr/env/python
+"""Write a virtual Zaar with icechunk """
+
+import glob
+import xarray as xr
+from virtualizarr import open_virtual_dataset
+import icechunk
+
+# could replace with URLs 
+paths = glob.glob("GEOS-DYAMOND2-data/DYAMONDv2_c2880_L181.inst_01hr_3d_*.nc4")
+
+all = xr.merge([
+	open_virtual_dataset(p, 
+		drop_variables=[
+		        "anchor",
+		        "cubed_sphere",
+		        "orientation",
+		        "contacts",
+		        "corner_lats",
+		        "corner_lons",
+		    ],) for p in paths], 
+  compat="override", 
+)
+
+storage = icechunk.local_filesystem_storage("./local/icechunk/store")
+repo = icechunk.Repository.create(storage)
+session = repo.writable_session("main")
+
+all.virtualize.to_icechunk(session.store)
+session.commit("Wrote first dataset")
+session.close() 
+
+ds = xr.open_zarr(
+    session.store,
+    zarr_version=3,
+    consolidated=False,
+    chunks={},
+)

--- a/examples/fetch-DYAMOND-data.py
+++ b/examples/fetch-DYAMOND-data.py
@@ -20,7 +20,7 @@ sim = "DYAMONDv2_c2880_L181"
 urls = [
     f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
     + f"inst_01hr_3d_{v}_Mv/{ym}/{sim}.inst_01hr_3d_{v}_Mv.{ymd}_0900z.nc4"
-    for v in ["QL", "QI", "RL", "RI", "DELP", "P", "CO2", "QV", "T"]
+    for v in ["QL", "QI", "RL", "RI", "DELP"]
 ]
 
 if compute_gas_optics:

--- a/examples/fetch-DYAMOND-data.py
+++ b/examples/fetch-DYAMOND-data.py
@@ -1,35 +1,36 @@
-#! /usr/env/python 
+#! /usr/env/python
 
 #
-# Download sample data on which to exercise pyRTE. 
-#   Data comes from the NASA/GMAO contribution to DYAMOND2 described at 
+# Download sample data on which to exercise pyRTE.
+#   Data comes from the NASA/GMAO contribution to DYAMOND2 described at
 #   https://gmao.gsfc.nasa.gov/global_mesoscale/dyamond_phaseII/data_access/
 #   Data is on a cubed sphere at resolution c2880 (~3.5 km globally, or about 50 million columns)
 #   Files are about 6Gb per snapshot (we choose Feb 1 at 9 Z); files for cloud variables are smaller
 #
 
 urls = [
-  f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/inst_01hr_3d_{v}_Mv/202002/DYAMONDv2_c2880_L181.inst_01hr_3d_{v}_Mv.20200201_0900z.nc4"
-  for v in ["QL", "QI", "RL", "RI", "DELP", "CO2", "QV", "T", "P"]
+    f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/inst_01hr_3d_{v}_Mv/202002/DYAMONDv2_c2880_L181.inst_01hr_3d_{v}_Mv.20200201_0900z.nc4"
+    for v in ["QL", "QI", "RL", "RI", "DELP", "CO2", "QV", "T", "P"]
 ]
 #
 # Ozone is 6-hourly
 #
-urls.append(["https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/geosgcm_prog/202002/DYAMONDv2_c2880_L181.geosgcm_prog.20200201_0600z.nc4"])
+urls.append(
+    [
+        "https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/geosgcm_prog/202002/DYAMONDv2_c2880_L181.geosgcm_prog.20200201_0600z.nc4"
+    ]
+)
 
 
-import pooch 
-from pathlib import Path 
+from pathlib import Path
+
+import pooch
 
 data_dir = "GEOS-DYAMOND2-data"
 with open("registry.txt", "w") as registry:
-  for u in urls: 
-    fname=Path(u).parts[-1]
-    # Download each data file to the specified directory
-    path = pooch.retrieve(
-        url=u, known_hash=None, fname=fname, path=data_dir
-    )
-    # Add the name, hash, and url of the file to the new registry file
-    registry.write(
-        f"{fname} {pooch.file_hash(path)} {u}\n"
-    )
+    for u in urls:
+        fname = Path(u).parts[-1]
+        # Download each data file to the specified directory
+        path = pooch.retrieve(url=u, known_hash=None, fname=fname, path=data_dir)
+        # Add the name, hash, and url of the file to the new registry file
+        registry.write(f"{fname} {pooch.file_hash(path)} {u}\n")

--- a/examples/fetch-DYAMOND-data.py
+++ b/examples/fetch-DYAMOND-data.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pooch
 
+compute_gas_optics = False
+
 ymd = "20200201"
 ym = ymd[:-2]
 sim = "DYAMONDv2_c2880_L181"
@@ -18,15 +20,21 @@ sim = "DYAMONDv2_c2880_L181"
 urls = [
     f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
     + f"inst_01hr_3d_{v}_Mv/{ym}/{sim}.inst_01hr_3d_{v}_Mv.{ymd}_0900z.nc4"
-    for v in ["QL", "QI", "RL", "RI", "DELP", "CO2", "QV", "T", "P"]
+    for v in ["QL", "QI", "RL", "RI", "DELP", "P", "CO2", "QV", "T"]
 ]
-#
-# Ozone is 6-hourly
-#
-urls.append(
-    f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
-    + f"geosgcm_prog/{ym}/{sim}.geosgcm_prog.{ymd}_0600z.nc4"
-)
+
+if compute_gas_optics:
+    for v in  ["P", "CO2", "QV", "T"]:
+      urls.append(
+        f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
+        + f"inst_01hr_3d_{v}_Mv/{ym}/{sim}.inst_01hr_3d_{v}_Mv.{ymd}_0900z.nc4")
+    #
+    # Ozone is 6-hourly
+    #
+    urls.append(
+        f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
+        + f"geosgcm_prog/{ym}/{sim}.geosgcm_prog.{ymd}_0600z.nc4"
+    )
 
 data_dir = "GEOS-DYAMOND2-data"
 with open("registry.txt", "w") as registry:

--- a/examples/fetch-DYAMOND-data.py
+++ b/examples/fetch-DYAMOND-data.py
@@ -3,24 +3,29 @@
 #
 #   Data comes from the NASA/GMAO contribution to DYAMOND2 described at
 #   https://gmao.gsfc.nasa.gov/global_mesoscale/dyamond_phaseII/data_access/
-#   Data is on a cubed sphere at resolution c2880 (~3.5 km globally, or about 50 million columns)
-#   Files are about 6Gb per snapshot (we choose Feb 1 at 9 Z); files for cloud variables are smaller
+#   Data is on a cubed sphere at resolution c2880
+#   (~3.5 km globally, or about 50 million columns). Files are about
+#   6Gb per snapshot (we choose Feb 1 at 9 Z); files for cloud variables are smaller
 #
 from pathlib import Path
 
 import pooch
 
+ymd = "20200201"
+ym = ymd[:-2]
+sim = "DYAMONDv2_c2880_L181"
+
 urls = [
-    "https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/"
-    + f"inst_01hr_3d_{v}_Mv/202002/DYAMONDv2_c2880_L181.inst_01hr_3d_{v}_Mv.20200201_0900z.nc4"
+    f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
+    + f"inst_01hr_3d_{v}_Mv/{ym}/{sim}.inst_01hr_3d_{v}_Mv.{ymd}_0900z.nc4"
     for v in ["QL", "QI", "RL", "RI", "DELP", "CO2", "QV", "T", "P"]
 ]
 #
 # Ozone is 6-hourly
 #
 urls.append(
-    "https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/"
-    + "geosgcm_prog/202002/DYAMONDv2_c2880_L181.geosgcm_prog.20200201_0600z.nc4"
+    f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
+    + f"geosgcm_prog/{ym}/{sim}.geosgcm_prog.{ymd}_0600z.nc4"
 )
 
 data_dir = "GEOS-DYAMOND2-data"

--- a/examples/fetch-DYAMOND-data.py
+++ b/examples/fetch-DYAMOND-data.py
@@ -24,10 +24,11 @@ urls = [
 ]
 
 if compute_gas_optics:
-    for v in  ["P", "CO2", "QV", "T"]:
-      urls.append(
-        f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
-        + f"inst_01hr_3d_{v}_Mv/{ym}/{sim}.inst_01hr_3d_{v}_Mv.{ymd}_0900z.nc4")
+    for v in ["P", "CO2", "QV", "T"]:
+        urls.append(
+            f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/{sim}/"
+            + f"inst_01hr_3d_{v}_Mv/{ym}/{sim}.inst_01hr_3d_{v}_Mv.{ymd}_0900z.nc4"
+        )
     #
     # Ozone is 6-hourly
     #

--- a/examples/fetch-DYAMOND-data.py
+++ b/examples/fetch-DYAMOND-data.py
@@ -1,30 +1,27 @@
 #! /usr/env/python
-
+"""Download sample data on which to exercise pyRTE."""
 #
-# Download sample data on which to exercise pyRTE.
 #   Data comes from the NASA/GMAO contribution to DYAMOND2 described at
 #   https://gmao.gsfc.nasa.gov/global_mesoscale/dyamond_phaseII/data_access/
 #   Data is on a cubed sphere at resolution c2880 (~3.5 km globally, or about 50 million columns)
 #   Files are about 6Gb per snapshot (we choose Feb 1 at 9 Z); files for cloud variables are smaller
 #
+from pathlib import Path
+
+import pooch
 
 urls = [
-    f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/inst_01hr_3d_{v}_Mv/202002/DYAMONDv2_c2880_L181.inst_01hr_3d_{v}_Mv.20200201_0900z.nc4"
+    "https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/"
+    + f"inst_01hr_3d_{v}_Mv/202002/DYAMONDv2_c2880_L181.inst_01hr_3d_{v}_Mv.20200201_0900z.nc4"
     for v in ["QL", "QI", "RL", "RI", "DELP", "CO2", "QV", "T", "P"]
 ]
 #
 # Ozone is 6-hourly
 #
 urls.append(
-    [
-        "https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/geosgcm_prog/202002/DYAMONDv2_c2880_L181.geosgcm_prog.20200201_0600z.nc4"
-    ]
+    "https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/"
+    + "geosgcm_prog/202002/DYAMONDv2_c2880_L181.geosgcm_prog.20200201_0600z.nc4"
 )
-
-
-from pathlib import Path
-
-import pooch
 
 data_dir = "GEOS-DYAMOND2-data"
 with open("registry.txt", "w") as registry:

--- a/examples/fetch-DYAMOND-data.py
+++ b/examples/fetch-DYAMOND-data.py
@@ -1,0 +1,35 @@
+#! /usr/env/python 
+
+#
+# Download sample data on which to exercise pyRTE. 
+#   Data comes from the NASA/GMAO contribution to DYAMOND2 described at 
+#   https://gmao.gsfc.nasa.gov/global_mesoscale/dyamond_phaseII/data_access/
+#   Data is on a cubed sphere at resolution c2880 (~3.5 km globally, or about 50 million columns)
+#   Files are about 6Gb per snapshot (we choose Feb 1 at 9 Z); files for cloud variables are smaller
+#
+
+urls = [
+  f"https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/inst_01hr_3d_{v}_Mv/202002/DYAMONDv2_c2880_L181.inst_01hr_3d_{v}_Mv.20200201_0900z.nc4"
+  for v in ["QL", "QI", "RL", "RI", "DELP", "CO2", "QV", "T", "P"]
+]
+#
+# Ozone is 6-hourly
+#
+urls.append(["https://portal.nccs.nasa.gov/datashare/G5NR/DYAMONDv2/03KM/DYAMONDv2_c2880_L181/geosgcm_prog/202002/DYAMONDv2_c2880_L181.geosgcm_prog.20200201_0600z.nc4"])
+
+
+import pooch 
+from pathlib import Path 
+
+data_dir = "GEOS-DYAMOND2-data"
+with open("registry.txt", "w") as registry:
+  for u in urls: 
+    fname=Path(u).parts[-1]
+    # Download each data file to the specified directory
+    path = pooch.retrieve(
+        url=u, known_hash=None, fname=fname, path=data_dir
+    )
+    # Add the name, hash, and url of the file to the new registry file
+    registry.write(
+        f"{fname} {pooch.file_hash(path)} {u}\n"
+    )


### PR DESCRIPTION
Provides the skeleton for cloud optics calculation on LOTS of data. 

Script `fetch-DYAMOND-data.py` uses `pooch` to download the fields needed to compute cloud (and gas) optics. 

Script `cloud_optics_example.py` assembles the files into an xarray dataset. We'd like to compute cloud optics on these but the existing datasets will need some massaging first... a useful test case. 