### PR TITLE
Small fixes

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - cmake >=3.18
     - git >=2.44.0
     - libuv >=1.44.2
-    - ninja
+    - ninja >=1.10
     - python
 
   host:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrte_rrtmgp"
-version = "0.0.6"
+version = "0.0.7"
 description = "A Python interface to the RTE+RRTMGP Fortran software package."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"


### PR DESCRIPTION
Update the pyproject.toml file to reflect the new version 0.0.7
Otherwise building the package with pip will produce a module with the old version.

Update minimum required ninja version in conda to 1.10 because that version adds Fortran support