### PR TITLE
Expand all-sky example

### DIFF
--- a/examples/all_sky_example.ipynb
+++ b/examples/all_sky_example.ipynb
@@ -120,7 +120,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Longwave calculations"
+    "## Longwave calculations\n",
+    "\n",
+    "In this example datasets are saved to intermediate variables at each step"
    ]
   },
   {
@@ -162,10 +164,11 @@
     "# Temporary workaround - compute_clouds() needs to know the particle size; that's \n",
     "#   set as the mid-point of the valid range from cloud_optics\n",
     "#\n",
-    "cloud_properties = compute_clouds(\n",
+    "cloud_props = compute_clouds(\n",
     "    cloud_optics_lw, atmosphere[\"pres_layer\"], atmosphere[\"temp_layer\"]\n",
     ")\n",
-    "atmosphere = atmosphere.merge(cloud_properties)\n"
+    "\n",
+    "atmosphere = atmosphere.merge(cloud_props)"
    ]
   },
   {
@@ -181,10 +184,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "clear_sky_optical_props = gas_optics_lw.compute_gas_optics(\n",
+    "optical_props = gas_optics_lw.compute_gas_optics(\n",
     "    atmosphere, problem_type=\"absorption\", add_to_input=False\n",
     ")\n",
-    "clear_sky_optical_props[\"surface_emissivity\"] = 0.98\n"
+    "optical_props[\"surface_emissivity\"] = 0.98\n"
    ]
   },
   {
@@ -204,7 +207,7 @@
     "    atmosphere, problem_type=\"absorption\"\n",
     ")\n",
     "\n",
-    "clouds_optical_props.add_to(clear_sky_optical_props)"
+    "clouds_optical_props.add_to(optical_props)"
    ]
   },
   {
@@ -220,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fluxes = rte_solve(clear_sky_optical_props, add_to_input=False)"
+    "fluxes = rte_solve(optical_props, add_to_input=False)"
    ]
   },
   {
@@ -254,7 +257,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Shortwave calculations"
+    "# Shortwave calculations\n",
+    "\n",
+    "In this example steps are combined where possible"
    ]
   },
   {
@@ -296,10 +301,9 @@
     "# Temporary workaround - compute_clouds() needs to know the particle size; that's \n",
     "#   set as the mid-point of the valid range from cloud_optics\n",
     "#\n",
-    "cloud_properties = compute_clouds(\n",
-    "    cloud_optics_sw, atmosphere[\"pres_layer\"], atmosphere[\"temp_layer\"]\n",
+    "atmosphere = atmosphere.merge(compute_clouds(\n",
+    "    cloud_optics_sw, atmosphere[\"pres_layer\"], atmosphere[\"temp_layer\"])\n",
     ")\n",
-    "atmosphere = atmosphere.merge(cloud_properties)\n",
     "#\n",
     "# Add SW-specific surface and angle properties\n",
     "#   At present these need to be in the dataset to compute gas optical properties but that should change \n",
@@ -327,7 +331,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Clear-sky (gases) optical properties; surface boundary conditions and solar zenith angle cosine"
+    "### Compute gas and cloud optics and combine in one step"
    ]
   },
   {
@@ -336,27 +340,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "optical_props = gas_optics_sw.compute_gas_optics(\n",
-    "    atmosphere, problem_type=\"two-stream\", add_to_input=False\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Calculate cloud properties; create all-sky optical properties"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Returns two-stream properties by default?\n",
-    "clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)\n",
-    "clouds_optical_props.add_to(optical_props, delta_scale=True)"
+    "# compute_cloud_optics() returns two-stream properties by default?\n",
+    "optical_props = gas_optics_sw.compute_gas_optics(atmosphere, problem_type=\"two-stream\", add_to_input=False)\n",
+    "# add_to() changes the values in optical_props\n",
+    "cloud_optics_sw.compute_cloud_optics(atmosphere).add_to(optical_props, delta_scale=True)"
    ]
   },
   {
@@ -368,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/all_sky_example.ipynb
+++ b/examples/all_sky_example.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,6 +72,7 @@
     "    AllSkyExampleFiles,\n",
     "    CloudOpticsFiles,\n",
     "    GasOpticsFiles,\n",
+    "    OpticsProblemTypes,\n",
     ")\n",
     "from pyrte_rrtmgp.rte_solver import rte_solve\n",
     "from pyrte_rrtmgp.utils import (\n",
@@ -180,12 +181,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "optical_props = gas_optics_lw.compute_gas_optics(\n",
-    "    atmosphere, problem_type=\"absorption\", add_to_input=False\n",
+    "    atmosphere, problem_type=OpticsProblemTypes.ABSORPTION, add_to_input=False\n",
     ")\n",
     "optical_props[\"surface_emissivity\"] = 0.98\n"
    ]
@@ -199,12 +200,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "clouds_optical_props = cloud_optics_lw.compute_cloud_optics(\n",
-    "    atmosphere, problem_type=\"absorption\"\n",
+    "    atmosphere, problem_type=OpticsProblemTypes.ABSORPTION\n",
     ")\n",
     "\n",
     "clouds_optical_props.add_to(optical_props)"
@@ -292,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,27 +304,6 @@
     "#\n",
     "atmosphere = atmosphere.merge(compute_clouds(\n",
     "    cloud_optics_sw, atmosphere[\"pres_layer\"], atmosphere[\"temp_layer\"])\n",
-    ")\n",
-    "#\n",
-    "# Add SW-specific surface and angle properties\n",
-    "#   At present these need to be in the dataset to compute gas optical properties but that should change \n",
-    "#\n",
-    "atmosphere[\"surface_albedo_dir\"] = 0.06\n",
-    "atmosphere[\"surface_albedo_dif\"] = 0.06\n",
-    "atmosphere[\"mu0\"] =  0.86\n",
-    "\n",
-    "#\n",
-    "# Replace the scalars above with arrays\n",
-    "#\n",
-    "ngpt = gas_optics_sw.sizes[\"gpt\"]\n",
-    "atmosphere[\"surface_albedo_dir\"] = xr.DataArray(\n",
-    "    np.full((atmosphere.h2o.shape[0], ngpt), 0.06), dims=[\"site\", \"gpt\"]\n",
-    ")\n",
-    "atmosphere[\"surface_albedo_dif\"] = xr.DataArray(\n",
-    "    np.full((atmosphere.h2o.shape[0], ngpt), 0.06), dims=[\"site\", \"gpt\"]\n",
-    ")\n",
-    "atmosphere[\"mu0\"] = xr.DataArray(\n",
-    "    np.full(atmosphere.h2o.shape,            0.86), dims=[\"site\", \"layer\"],\n",
     ")"
    ]
   },
@@ -336,14 +316,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# compute_cloud_optics() returns two-stream properties by default?\n",
-    "optical_props = gas_optics_sw.compute_gas_optics(atmosphere, problem_type=\"two-stream\", add_to_input=False)\n",
+    "optical_props = gas_optics_sw.compute_gas_optics(atmosphere, problem_type=OpticsProblemTypes.TWO_STREAM, add_to_input=False)\n",
     "# add_to() changes the values in optical_props\n",
-    "cloud_optics_sw.compute_cloud_optics(atmosphere).add_to(optical_props, delta_scale=True)"
+    "cloud_optics_sw.compute_cloud_optics(atmosphere).add_to(optical_props, delta_scale=True)\n",
+    "#\n",
+    "# Add SW-specific surface and angle properties\n",
+    "#\n",
+    "optical_props[\"surface_albedo_dir\"] = 0.06\n",
+    "optical_props[\"surface_albedo_dif\"] = 0.06\n",
+    "optical_props[\"mu0\"] =  0.86"
    ]
   },
   {

--- a/examples/all_sky_example.ipynb
+++ b/examples/all_sky_example.ipynb
@@ -1,14 +1,72 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# All-sky Radiative Transfer Example with PyRTE-RRTMGP\n",
+    "\n",
+    "This notebook demonstrates how to use the PyRTE-RRTMGP package to solve an idealized problem including clouds and clear skies. PyRTE-RRTMGP is a Python implementation of the Radiative Transfer for Energetics (RTE).\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "PyRTE-RRTMGP provides a flexible and efficient framework for computing radiative fluxes in planetary atmospheres. This example shows an end-to-end problem with both clear skies and clouds. \n",
+    "\n",
+    "1. Loading data for cloud and gas optics \n",
+    "2. Computing gas and cloud optical properties and combining them to produce an all-sky problem\n",
+    "3. Solving the radiative transfer equation to obtain upward and downward fluxes\n",
+    "4. Validating results against reference solutions generated with the original RTE fortran code\n",
+    "\n",
+    "The package leverages `xarray` to represent data.\n",
+    "\n",
+    "## Key Components\n",
+    "\n",
+    "- **Gas and Cloud Optics**: Handles spectral properties of atmospheric gases and clouds and combines them to make a complete problem\n",
+    "- **RTE Solver**: Computes radiative fluxes based on atmospheric properties\n",
+    "- **Data Handling**: Uses xarray for labeled, multi-dimensional data structures\n",
+    "\n",
+    "This example demonstrates the workflow for both longwave and shortwave radiative transfer calculations.\n",
+    "\n",
+    "See the [documentation](https://pyrte-rrtmgp.readthedocs.io/en/latest/) for more information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preliminaries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installing dependencies"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import xarray as xr\n",
-    "\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Importing pyRTE components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from pyrte_rrtmgp import rrtmgp_cloud_optics, rrtmgp_gas_optics\n",
     "from pyrte_rrtmgp.data_types import (\n",
     "    AllSkyExampleFiles,\n",
@@ -20,55 +78,164 @@
     "    compute_clouds,\n",
     "    compute_profiles,\n",
     "    load_rrtmgp_file,\n",
-    ")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up the problem\n",
     "\n",
-    "ncol = 24\n",
-    "nlay = 72\n",
+    "The routine `compute_profiles()` packaged with `pyRTE_RRTMGP` computes temperature, pressure, and humidity profiles following a moist adibat. The concentrations of other gases are also needed. Clouds are distributed in 2/3 of the columns "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_profiles(ncol = 24, nlay = 72):\n",
+    "    # Create atmospheric profiles and gas concentrations\n",
+    "    atmosphere = compute_profiles(300, ncol, nlay)\n",
     "\n",
-    "# Create atmospheric profiles and gas concentrations\n",
-    "atmosphere = compute_profiles(300, ncol, nlay)\n",
+    "    # Add other gas values\n",
+    "    gas_values = {\n",
+    "        \"co2\": 348e-6,\n",
+    "        \"ch4\": 1650e-9,\n",
+    "        \"n2o\": 306e-9,\n",
+    "        \"n2\": 0.7808,\n",
+    "        \"o2\": 0.2095,\n",
+    "        \"co\": 0.0,\n",
+    "    }\n",
     "\n",
-    "# Add other gas values\n",
-    "gas_values = {\n",
-    "    \"co2\": 348e-6,\n",
-    "    \"ch4\": 1650e-9,\n",
-    "    \"n2o\": 306e-9,\n",
-    "    \"n2\": 0.7808,\n",
-    "    \"o2\": 0.2095,\n",
-    "    \"co\": 0.0,\n",
-    "}\n",
-    "\n",
-    "for gas_name, value in gas_values.items():\n",
-    "    atmosphere[gas_name] = xr.DataArray(\n",
-    "        np.full((ncol, nlay), value), dims=(\"site\", \"layer\")\n",
-    "    )\n",
-    "\n",
+    "    for gas_name, value in gas_values.items():\n",
+    "        atmosphere[gas_name] = value\n",
+    "    \n",
+    "    return atmosphere"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Longwave calculations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize the cloud and gas optics data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "cloud_optics_lw = rrtmgp_cloud_optics.load_cloud_optics(\n",
     "    cloud_optics_file=CloudOpticsFiles.LW_BND\n",
     ")\n",
-    "\n",
-    "# Calculate cloud properties and merge into the atmosphere dataset\n",
+    "gas_optics_lw = rrtmgp_gas_optics.load_gas_optics(\n",
+    "    gas_optics_file=GasOpticsFiles.LW_G256\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Atmospheric profiles - clear sky, then clouds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atmosphere = make_profiles()\n",
+    "#\n",
+    "# Temporary workaround - compute_clouds() needs to know the particle size; that's \n",
+    "#   set as the mid-point of the valid range from cloud_optics\n",
+    "#\n",
     "cloud_properties = compute_clouds(\n",
     "    cloud_optics_lw, atmosphere[\"pres_layer\"], atmosphere[\"temp_layer\"]\n",
     ")\n",
-    "atmosphere = atmosphere.merge(cloud_properties)\n",
-    "\n",
+    "atmosphere = atmosphere.merge(cloud_properties)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clear-sky (gases) optical properties; surface boundary conditions "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clear_sky_optical_props = gas_optics_lw.compute_gas_optics(\n",
+    "    atmosphere, problem_type=\"absorption\", add_to_input=False\n",
+    ")\n",
+    "clear_sky_optical_props[\"surface_emissivity\"] = 0.98\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate cloud properties; create all-sky optical properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "clouds_optical_props = cloud_optics_lw.compute_cloud_optics(\n",
     "    atmosphere, problem_type=\"absorption\"\n",
     ")\n",
     "\n",
-    "gas_optics_lw = rrtmgp_gas_optics.load_gas_optics(\n",
-    "    gas_optics_file=GasOpticsFiles.LW_G256\n",
-    ")\n",
-    "clear_sky_optical_props = gas_optics_lw.compute_gas_optics(\n",
-    "    atmosphere, problem_type=\"absorption\", add_to_input=False\n",
-    ")\n",
-    "clear_sky_optical_props[\"surface_emissivity\"] = 0.98\n",
-    "\n",
-    "# combine optical properties\n",
-    "clouds_optical_props.add_to(clear_sky_optical_props)\n",
-    "fluxes = rte_solve(clear_sky_optical_props, add_to_input=False)\n",
-    "\n",
+    "clouds_optical_props.add_to(clear_sky_optical_props)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute broadband fluxes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluxes = rte_solve(clear_sky_optical_props, add_to_input=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare to reference results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Load reference data and verify results\n",
     "ref_data = load_rrtmgp_file(AllSkyExampleFiles.LW_NO_AEROSOL)\n",
     "assert np.isclose(\n",
@@ -84,86 +251,143 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shortwave calculations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize optics data "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import xarray as xr\n",
-    "\n",
-    "from pyrte_rrtmgp import rrtmgp_cloud_optics, rrtmgp_gas_optics\n",
-    "from pyrte_rrtmgp.data_types import (\n",
-    "    AllSkyExampleFiles,\n",
-    "    CloudOpticsFiles,\n",
-    "    GasOpticsFiles,\n",
-    ")\n",
-    "from pyrte_rrtmgp.rte_solver import rte_solve\n",
-    "from pyrte_rrtmgp.utils import (\n",
-    "    compute_clouds,\n",
-    "    compute_profiles,\n",
-    "    load_rrtmgp_file,\n",
-    ")\n",
-    "\n",
-    "ncol = 24\n",
-    "nlay = 72\n",
-    "\n",
-    "# Create atmospheric profiles and gas concentrations\n",
-    "atmosphere = compute_profiles(300, ncol, nlay)\n",
-    "\n",
-    "# Add other gas values\n",
-    "gas_values = {\n",
-    "    \"co2\": 348e-6,\n",
-    "    \"ch4\": 1650e-9,\n",
-    "    \"n2o\": 306e-9,\n",
-    "    \"n2\": 0.7808,\n",
-    "    \"o2\": 0.2095,\n",
-    "    \"co\": 0.0,\n",
-    "}\n",
-    "\n",
-    "for gas_name, value in gas_values.items():\n",
-    "    atmosphere[gas_name] = xr.DataArray(\n",
-    "        np.full((ncol, nlay), value), dims=(\"site\", \"layer\")\n",
-    "    )\n",
-    "\n",
     "cloud_optics_sw = rrtmgp_cloud_optics.load_cloud_optics(\n",
     "    cloud_optics_file=CloudOpticsFiles.SW_BND\n",
     ")\n",
-    "\n",
-    "# Calculate cloud properties and merge into the atmosphere dataset\n",
+    "gas_optics_sw = rrtmgp_gas_optics.load_gas_optics(\n",
+    "    gas_optics_file=GasOpticsFiles.SW_G224\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Atmospheric profiles - clear sky, then clouds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atmosphere = make_profiles()\n",
+    "#\n",
+    "# Temporary workaround - compute_clouds() needs to know the particle size; that's \n",
+    "#   set as the mid-point of the valid range from cloud_optics\n",
+    "#\n",
     "cloud_properties = compute_clouds(\n",
     "    cloud_optics_sw, atmosphere[\"pres_layer\"], atmosphere[\"temp_layer\"]\n",
     ")\n",
-    "\n",
     "atmosphere = atmosphere.merge(cloud_properties)\n",
-    "\n",
-    "clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)\n",
-    "\n",
-    "gas_optics_sw = rrtmgp_gas_optics.load_gas_optics(\n",
-    "    gas_optics_file=GasOpticsFiles.SW_G224\n",
-    ")\n",
-    "\n",
+    "#\n",
     "# Add SW-specific surface and angle properties\n",
+    "#   At present these need to be in the dataset to compute gas optical properties but that should change \n",
+    "#\n",
+    "atmosphere[\"surface_albedo_dir\"] = 0.06\n",
+    "atmosphere[\"surface_albedo_dif\"] = 0.06\n",
+    "atmosphere[\"mu0\"] =  0.86\n",
+    "\n",
+    "#\n",
+    "# Replace the scalars above with arrays\n",
+    "#\n",
     "ngpt = gas_optics_sw.sizes[\"gpt\"]\n",
     "atmosphere[\"surface_albedo_dir\"] = xr.DataArray(\n",
-    "    np.full((ncol, ngpt), 0.06), dims=[\"site\", \"gpt\"]\n",
+    "    np.full((atmosphere.h2o.shape[0], ngpt), 0.06), dims=[\"site\", \"gpt\"]\n",
     ")\n",
     "atmosphere[\"surface_albedo_dif\"] = xr.DataArray(\n",
-    "    np.full((ncol, ngpt), 0.06), dims=[\"site\", \"gpt\"]\n",
+    "    np.full((atmosphere.h2o.shape[0], ngpt), 0.06), dims=[\"site\", \"gpt\"]\n",
     ")\n",
     "atmosphere[\"mu0\"] = xr.DataArray(\n",
-    "    np.full((ncol, nlay), 0.86),\n",
-    "    dims=[\"site\", \"layer\"],\n",
-    ")\n",
-    "\n",
-    "# Calculate gas optical properties\n",
-    "clear_sky_optical_props = gas_optics_sw.compute_gas_optics(\n",
+    "    np.full(atmosphere.h2o.shape,            0.86), dims=[\"site\", \"layer\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clear-sky (gases) optical properties; surface boundary conditions and solar zenith angle cosine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optical_props = gas_optics_sw.compute_gas_optics(\n",
     "    atmosphere, problem_type=\"two-stream\", add_to_input=False\n",
-    ")\n",
-    "\n",
-    "clouds_optical_props.add_to(clear_sky_optical_props, delta_scale=True)\n",
-    "fluxes = rte_solve(clear_sky_optical_props, add_to_input=False)\n",
-    "\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate cloud properties; create all-sky optical properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Returns two-stream properties by default?\n",
+    "clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)\n",
+    "clouds_optical_props.add_to(optical_props, delta_scale=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute fluxes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluxes = rte_solve(optical_props, add_to_input=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare to reference results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ref_data = load_rrtmgp_file(AllSkyExampleFiles.SW_NO_AEROSOL)\n",
     "assert np.isclose(\n",
     "    fluxes[\"sw_flux_up\"],\n",
@@ -174,15 +398,20 @@
     "    fluxes[\"sw_flux_down\"],\n",
     "    ref_data[\"sw_flux_dn\"].T,\n",
     "    atol=1e-7,\n",
+    ").all()\n",
+    "assert np.isclose(\n",
+    "    fluxes[\"sw_flux_dir\"],\n",
+    "    ref_data[\"sw_flux_dir\"].T,\n",
+    "    atol=1e-7,\n",
     ").all()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyrte",
+   "display_name": "pyRTE",
    "language": "python",
-   "name": "python3"
+   "name": "pyrte"
   },
   "language_info": {
    "codemirror_mode": {
@@ -194,9 +423,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The idealized all-sky example notebook is expanded with more annotation, different approaches to combining steps, etc. 

Addresses point 2 of #148 

The PR is a draft because I don't have a way to update my Python dev environment to the current state of `main`. If others can do so and confirm the notebook runs please feel free to convert to a full PR and even to merge. 

@tcmetzger @brendancol @sehnem ? 