### PR TITLE
updated tests to use OpticProblemTypes enum

### DIFF
--- a/pyrte_rrtmgp/tests/test_cld_lw_solver.py
+++ b/pyrte_rrtmgp/tests/test_cld_lw_solver.py
@@ -3,8 +3,16 @@ import numpy as np
 
 from pyrte_rrtmgp import rrtmgp_cloud_optics
 from pyrte_rrtmgp import rrtmgp_gas_optics
-from pyrte_rrtmgp.data_types import CloudOpticsFiles, GasOpticsFiles, AllSkyExampleFiles
-from pyrte_rrtmgp.utils import compute_profiles, compute_clouds, load_rrtmgp_file
+
+from pyrte_rrtmgp.data_types import AllSkyExampleFiles
+from pyrte_rrtmgp.data_types import CloudOpticsFiles
+from pyrte_rrtmgp.data_types import GasOpticsFiles
+from pyrte_rrtmgp.data_types import OpticsProblemTypes
+
+from pyrte_rrtmgp.utils import compute_profiles
+from pyrte_rrtmgp.utils import compute_clouds
+from pyrte_rrtmgp.utils import load_rrtmgp_file
+
 from pyrte_rrtmgp.rte_solver import rte_solve
 
 
@@ -46,7 +54,7 @@ def test_lw_solver_with_clouds() -> None:
 
     # Calculate cloud optical properties
     clouds_optical_props = cloud_optics_lw.compute_cloud_optics(
-        atmosphere, problem_type="absorption"
+        atmosphere, problem_type=OpticsProblemTypes.ABSORPTION
     )
 
     # Calculate gas optical properties
@@ -54,7 +62,9 @@ def test_lw_solver_with_clouds() -> None:
         gas_optics_file=GasOpticsFiles.LW_G256
     )
     optical_props = gas_optics_lw.compute_gas_optics(
-        atmosphere, problem_type="absorption", add_to_input=False
+        atmosphere,
+        problem_type=OpticsProblemTypes.ABSORPTION,
+        add_to_input=False
     )
     optical_props["surface_emissivity"] = 0.98
 
@@ -66,5 +76,7 @@ def test_lw_solver_with_clouds() -> None:
 
     # Load reference data and verify results
     ref_data = load_rrtmgp_file(AllSkyExampleFiles.LW_NO_AEROSOL)
-    assert np.isclose(fluxes["lw_flux_up"], ref_data["lw_flux_up"].T, atol=1e-7).all()
-    assert np.isclose(fluxes["lw_flux_down"], ref_data["lw_flux_dn"].T, atol=1e-7).all()
+    assert np.isclose(fluxes["lw_flux_up"],
+                      ref_data["lw_flux_up"].T, atol=1e-7).all()
+    assert np.isclose(fluxes["lw_flux_down"],
+                      ref_data["lw_flux_dn"].T, atol=1e-7).all()

--- a/pyrte_rrtmgp/tests/test_cld_sw_solver.py
+++ b/pyrte_rrtmgp/tests/test_cld_sw_solver.py
@@ -3,8 +3,16 @@ import numpy as np
 
 from pyrte_rrtmgp import rrtmgp_cloud_optics
 from pyrte_rrtmgp import rrtmgp_gas_optics
-from pyrte_rrtmgp.data_types import CloudOpticsFiles, GasOpticsFiles, AllSkyExampleFiles
-from pyrte_rrtmgp.utils import compute_profiles, compute_clouds, load_rrtmgp_file
+
+from pyrte_rrtmgp.data_types import AllSkyExampleFiles
+from pyrte_rrtmgp.data_types import CloudOpticsFiles
+from pyrte_rrtmgp.data_types import GasOpticsFiles
+from pyrte_rrtmgp.data_types import OpticsProblemTypes
+
+from pyrte_rrtmgp.utils import compute_profiles
+from pyrte_rrtmgp.utils import compute_clouds
+from pyrte_rrtmgp.utils import load_rrtmgp_file
+
 from pyrte_rrtmgp.rte_solver import rte_solve
 
 
@@ -54,7 +62,9 @@ def test_sw_solver_with_clouds() -> None:
 
     # Calculate gas optical properties
     optical_props = gas_optics_sw.compute_gas_optics(
-        atmosphere, problem_type="two-stream", add_to_input=False
+        atmosphere,
+        problem_type=OpticsProblemTypes.TWO_STREAM,
+        add_to_input=False
     )
 
     # Combine optical properties and solve RTE
@@ -70,5 +80,7 @@ def test_sw_solver_with_clouds() -> None:
 
     # Load reference data and verify results
     ref_data = load_rrtmgp_file(AllSkyExampleFiles.SW_NO_AEROSOL)
-    assert np.isclose(fluxes["sw_flux_up"], ref_data["sw_flux_up"].T, atol=1e-7).all()
-    assert np.isclose(fluxes["sw_flux_down"], ref_data["sw_flux_dn"].T, atol=1e-7).all()
+    assert np.isclose(fluxes["sw_flux_up"],
+                      ref_data["sw_flux_up"].T, atol=1e-7).all()
+    assert np.isclose(fluxes["sw_flux_down"],
+                      ref_data["sw_flux_dn"].T, atol=1e-7).all()

--- a/pyrte_rrtmgp/tests/test_lw_solver.py
+++ b/pyrte_rrtmgp/tests/test_lw_solver.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from pyrte_rrtmgp.data_types import RFMIPExampleFiles, GasOpticsFiles
+from pyrte_rrtmgp.data_types import GasOpticsFiles
+from pyrte_rrtmgp.data_types import OpticsProblemTypes
+from pyrte_rrtmgp.data_types import RFMIPExampleFiles
+
 from pyrte_rrtmgp.utils import load_rrtmgp_file
 from pyrte_rrtmgp import rrtmgp_gas_optics
 from pyrte_rrtmgp.rte_solver import rte_solve
@@ -42,7 +45,9 @@ def test_lw_solver_noscat() -> None:
 
     # Compute gas optics for the atmosphere
     gas_optics_lw.compute_gas_optics(
-        atmosphere, problem_type="absorption", gas_name_map=gas_mapping
+        atmosphere,
+        problem_type=OpticsProblemTypes.ABSORPTION,
+        gas_name_map=gas_mapping
     )
 
     # Solve RTE
@@ -56,5 +61,7 @@ def test_lw_solver_noscat() -> None:
     ref_flux_down = rld.isel(expt=0)["rld"]
 
     # Compare results with reference data
-    assert np.isclose(fluxes["lw_flux_up"], ref_flux_up, atol=ERROR_TOLERANCE).all()
-    assert np.isclose(fluxes["lw_flux_down"], ref_flux_down, atol=ERROR_TOLERANCE).all()
+    assert np.isclose(fluxes["lw_flux_up"],
+                      ref_flux_up, atol=ERROR_TOLERANCE).all()
+    assert np.isclose(fluxes["lw_flux_down"],
+                      ref_flux_down, atol=ERROR_TOLERANCE).all()

--- a/pyrte_rrtmgp/tests/test_sw_solver.py
+++ b/pyrte_rrtmgp/tests/test_sw_solver.py
@@ -1,6 +1,6 @@
 import numpy as np
-import xarray as xr
 
+from pyrte_rrtmgp.data_types import OpticsProblemTypes
 from pyrte_rrtmgp.data_types import RFMIPExampleFiles
 from pyrte_rrtmgp.rrtmgp_gas_optics import GasOpticsFiles, load_gas_optics
 from pyrte_rrtmgp.rte_solver import rte_solve
@@ -41,7 +41,9 @@ def test_sw_solver_noscat() -> None:
 
     # Compute gas optics for the atmosphere
     gas_optics_sw.compute_gas_optics(
-        atmosphere, problem_type="two-stream", gas_name_map=gas_mapping
+        atmosphere,
+        problem_type=OpticsProblemTypes.TWO_STREAM,
+        gas_name_map=gas_mapping
     )
 
     # Solve RTE
@@ -55,5 +57,7 @@ def test_sw_solver_noscat() -> None:
     ref_flux_down = rsd.isel(expt=0)["rsd"]
 
     # Compare results with reference data
-    assert np.isclose(fluxes["sw_flux_up"], ref_flux_up, atol=ERROR_TOLERANCE).all()
-    assert np.isclose(fluxes["sw_flux_down"], ref_flux_down, atol=ERROR_TOLERANCE).all()
+    assert np.isclose(fluxes["sw_flux_up"],
+                      ref_flux_up, atol=ERROR_TOLERANCE).all()
+    assert np.isclose(fluxes["sw_flux_down"],
+                      ref_flux_down, atol=ERROR_TOLERANCE).all()


### PR DESCRIPTION
There were a couple more spots still using literal string for `problem_type` which have been updated here. fixes #151 