### PR TITLE
Don't report LW Jacobians

### DIFF
--- a/pyrte_rrtmgp/kernels/rte.py
+++ b/pyrte_rrtmgp/kernels/rte.py
@@ -47,7 +47,6 @@ def lw_solver_noscat(
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
-    npt.NDArray[np.float64],
 ]:
     """Perform longwave radiation transfer calculations without scattering.
 
@@ -124,7 +123,7 @@ def lw_solver_noscat(
 
     rte_lw_solver_noscat(*args)
 
-    return flux_up_jac, broadband_up, broadband_dn, flux_up, flux_dn
+    return broadband_up, broadband_dn, flux_up, flux_dn
 
 
 def lw_solver_2stream(

--- a/pyrte_rrtmgp/rte_solver.py
+++ b/pyrte_rrtmgp/rte_solver.py
@@ -126,7 +126,6 @@ def _compute_lw_fluxes_absorption(
 
     Returns:
         Dataset containing the computed fluxes:
-            - lw_flux_up_jacobian: Upward flux Jacobian
             - lw_flux_up_broadband: Broadband upward flux
             - lw_flux_down_broadband: Broadband downward flux
             - lw_flux_up: Spectrally resolved upward flux
@@ -165,7 +164,6 @@ def _compute_lw_fluxes_absorption(
     g: xr.DataArray = problem_ds["g"] if "g" in problem_ds else problem_ds["tau"].copy()
 
     (
-        solver_flux_up_jacobian,
         solver_flux_up_broadband,
         solver_flux_down_broadband,
         _,
@@ -202,7 +200,6 @@ def _compute_lw_fluxes_absorption(
             ["gpt"],  # inc_flux
         ],
         output_core_dims=[
-            [level_dim],  # solver_flux_up_jacobian
             [level_dim],  # solver_flux_up_broadband
             [level_dim],  # solver_flux_down_broadband
             [level_dim, "gpt"],  # solver_flux_up
@@ -214,7 +211,6 @@ def _compute_lw_fluxes_absorption(
 
     fluxes = xr.Dataset(
         {
-            "lw_flux_up_jacobian": solver_flux_up_jacobian.unstack("stacked_cols"),
             "lw_flux_up": solver_flux_up_broadband.unstack("stacked_cols"),
             "lw_flux_down": solver_flux_down_broadband.unstack("stacked_cols"),
         }


### PR DESCRIPTION
Removes Jacobian of LW upwelling flux with respect to surface temperature from the outputs of the LW no-scattering solver. (Remaining instances are required because underlying Fortran kernels need memory allocated even if it's not accessed.) 