### PR TITLE
Made the add_to accessor conform to the function signature by returning the "other" value

### DIFF
--- a/pyrte_rrtmgp/rrtmgp_cloud_optics.py
+++ b/pyrte_rrtmgp/rrtmgp_cloud_optics.py
@@ -513,6 +513,8 @@ class CombineOpticalPropsAccessor:
             if var in op2.data_vars:
                 other[var] = op2[var].unstack("stacked_cols")
 
+        return other
+
     def delta_scale_optical_props(
         self, optical_props: xr.Dataset, forward_scattering: np.ndarray | None = None
     ) -> xr.Dataset:

--- a/pyrte_rrtmgp/tests/test_cld_lw_solver.py
+++ b/pyrte_rrtmgp/tests/test_cld_lw_solver.py
@@ -1,3 +1,4 @@
+import netCDF4 as nc  # noqa
 import xarray as xr
 import numpy as np
 
@@ -68,10 +69,8 @@ def test_lw_solver_with_clouds() -> None:
     )
     optical_props["surface_emissivity"] = 0.98
 
-    # Combine optical properties and solve RTE
-    clouds_optical_props.add_to(optical_props)
-
-    fluxes = rte_solve(optical_props, add_to_input=False)
+    fluxes = rte_solve(clouds_optical_props.add_to(optical_props),
+                       add_to_input=False)
     assert fluxes is not None
 
     # Load reference data and verify results

--- a/pyrte_rrtmgp/tests/test_cld_sw_solver.py
+++ b/pyrte_rrtmgp/tests/test_cld_sw_solver.py
@@ -77,15 +77,13 @@ def test_sw_solver_with_clouds() -> None:
         add_to_input=False
     )
 
-    # Combine optical properties and solve RTE
-    clouds_optical_props.add_to(optical_props, delta_scale=True)
-
     # Add SW-specific surface and angle properties
     optical_props["surface_albedo_direct"] = 0.06
     optical_props["surface_albedo_diffuse"] = 0.06
     optical_props["mu0"] = 0.86
 
-    fluxes = rte_solve(optical_props, add_to_input=False)
+    fluxes = rte_solve(clouds_optical_props.add_to(optical_props, delta_scale=True),
+                       add_to_input=False)
     assert fluxes is not None
 
     # Load reference data and verify results


### PR DESCRIPTION
fixes #144 

I went with a minimal fix here to simply conform to the stated signature of the function which was supposed to return an `xr.Dataset` but didn't.  By returning this value, it now support the more elegant syntax mentioned in #144.

Overall I think the use of an accessor here is a bit awkward and IMHO doesn't lead to easier spelling. 