### PR TITLE
added test for dask input to longwave solver with clouds

### DIFF
--- a/pyrte_rrtmgp/rrtmgp_gas_optics.py
+++ b/pyrte_rrtmgp/rrtmgp_gas_optics.py
@@ -5,6 +5,7 @@ import os
 import sys
 from typing import Iterable, cast
 
+import dask.array as da
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -146,7 +147,7 @@ class BaseGasOpticsAccessor:
             Modified atmosphere dataset if inplace=False, otherwise None
         """
         pres_level_var = atmosphere.mapping.get_var("pres_level")
-        min_press = self._dataset["press_ref"].min().item() + sys.float_info.epsilon
+        min_press = self._dataset["press_ref"].min() + sys.float_info.epsilon
 
         # Replace values smaller than min_press with min_press at min_index
         atmosphere[pres_level_var] = xr.where(
@@ -636,6 +637,12 @@ class BaseGasOpticsAccessor:
         zero_mask = np.all(all_flavors == [0, 0], axis=1)
         all_flavors[zero_mask] = [2, 2]
 
+        # NOTE: This is a workaround for the fact that dask array
+        # doesn't support np.unique with axis=0
+
+        if isinstance(all_flavors, da.Array):
+            all_flavors = all_flavors.compute()
+
         # Get unique flavors while preserving original order
         _, unique_indices = np.unique(all_flavors, axis=0, return_index=True)
         unique_flavors = all_flavors[np.sort(unique_indices)]
@@ -678,6 +685,9 @@ class BaseGasOpticsAccessor:
         Returns:
             Tuple of decoded and cleaned names
         """
+        if isinstance(names, da.Array):
+            names = names.compute()
+
         output = np.array(
             [gas.tobytes().decode().strip().split("_")[0] for gas in names]
         )

--- a/pyrte_rrtmgp/rrtmgp_gas_optics.py
+++ b/pyrte_rrtmgp/rrtmgp_gas_optics.py
@@ -987,6 +987,8 @@ class LWGasOpticsAccessor(BaseGasOpticsAccessor):
             dask="parallelized",
         )
 
+        # TODO: should chunks be added / perserved here for surface source arrays?
+        # TODO: should surface source arrays be dask arrays?
         return xr.Dataset(
             {
                 "surface_source": sfc_src.unstack("stacked_cols"),

--- a/pyrte_rrtmgp/tests/test_cld_lw_solver.py
+++ b/pyrte_rrtmgp/tests/test_cld_lw_solver.py
@@ -2,6 +2,8 @@ import netCDF4 as nc  # noqa
 import xarray as xr
 import numpy as np
 
+import dask.array as da
+
 from pyrte_rrtmgp import rrtmgp_cloud_optics
 from pyrte_rrtmgp import rrtmgp_gas_optics
 
@@ -71,6 +73,97 @@ def test_lw_solver_with_clouds() -> None:
 
     fluxes = rte_solve(clouds_optical_props.add_to(optical_props),
                        add_to_input=False)
+    assert fluxes is not None
+
+    # Load reference data and verify results
+    ref_data = load_rrtmgp_file(AllSkyExampleFiles.LW_NO_AEROSOL)
+    assert np.isclose(fluxes["lw_flux_up"],
+                      ref_data["lw_flux_up"].T, atol=1e-7).all()
+    assert np.isclose(fluxes["lw_flux_down"],
+                      ref_data["lw_flux_dn"].T, atol=1e-7).all()
+
+
+def test_lw_solver_with_clouds_dask() -> None:
+
+    # Set up dimensions
+    ncol = 24
+    nlay = 72
+
+    # Create atmospheric profiles and gas concentrations
+    atmosphere = compute_profiles(300, ncol, nlay)
+    atmosphere = atmosphere.chunk("auto")
+    assert isinstance(atmosphere, xr.Dataset)
+    assert isinstance(atmosphere["pres_layer"].data, da.Array)
+
+    # Add other gas values
+    gas_values = {
+        "co2": 348e-6,
+        "ch4": 1650e-9,
+        "n2o": 306e-9,
+        "n2": 0.7808,
+        "o2": 0.2095,
+        "co": 0.0,
+    }
+
+    for gas_name, value in gas_values.items():
+        atmosphere[gas_name] = xr.DataArray(
+            value,
+            dims=["site", "layer"],
+            coords={"site": range(ncol), "layer": range(nlay)})
+
+    # Load cloud optics data
+    cloud_optics_lw = rrtmgp_cloud_optics.load_cloud_optics(
+        cloud_optics_file=CloudOpticsFiles.LW_BND
+    )
+    cloud_optics_lw = cloud_optics_lw.chunk("auto")
+    assert isinstance(cloud_optics_lw, xr.Dataset)
+    assert isinstance(cloud_optics_lw["asyice"].data, da.Array)
+
+    # Calculate cloud properties and merge into the atmosphere dataset
+    cloud_properties = compute_clouds(
+        cloud_optics_lw, atmosphere["pres_layer"], atmosphere["temp_layer"]
+    )
+    assert isinstance(cloud_properties, xr.Dataset)
+    assert isinstance(cloud_properties["lwp"].data, da.Array)
+
+    atmosphere = atmosphere.merge(cloud_properties)
+
+    # Calculate cloud optical properties
+    clouds_optical_props = cloud_optics_lw.compute_cloud_optics(
+        atmosphere, problem_type=OpticsProblemTypes.ABSORPTION
+    )
+
+    assert isinstance(clouds_optical_props, xr.Dataset)
+    assert isinstance(clouds_optical_props["tau"].data, da.Array)
+
+    # Calculate gas optical properties
+    gas_optics_lw = rrtmgp_gas_optics.load_gas_optics(
+        gas_optics_file=GasOpticsFiles.LW_G256
+    )
+
+    # TODO: I don't think dask works with compute_gas_optics
+    optical_props = gas_optics_lw.compute_gas_optics(
+        atmosphere,
+        problem_type=OpticsProblemTypes.ABSORPTION,
+        add_to_input=False
+    )
+    optical_props["surface_emissivity"] = 0.98
+
+    # TODO: When chunking the optical_props values final isclose asserts
+    # optical_props = optical_props.chunk("auto")
+
+    problem_ds = clouds_optical_props.add_to(optical_props)
+    assert isinstance(problem_ds, xr.Dataset)
+
+    # TODO: tau should probably be dask array?
+    # assert isinstance(problem_ds["tau"].data, da.Array)
+
+    fluxes = rte_solve(problem_ds, add_to_input=False)
+
+    assert isinstance(fluxes, xr.Dataset)
+    # TODO: fluxes output is not dask array
+    # assert isinstance(fluxes["lw_flux_up"].data, da.Array)
+
     assert fluxes is not None
 
     # Load reference data and verify results


### PR DESCRIPTION
fixes #183 

This PR currently covers testing using dask.Array (via xarray) as input to `rte_solve` for long wave with clouds.

@sehnem I put a couple of `TODO:` messages in the `pyrte_rrtmgp/tests/test_cld_lw_solver.py`

```bash
git pull
git checkout fixes-183-add-dask-test-for-longwave-with-clouds-solver
pytest pyrte_rrtmgp/tests -k test_lw_solver_with_clouds_dask --pdb
```

Overall the test passes, but there are a few asserts that are commented out near the TODO messages I would love for you to look at before merging