### PR TITLE
added test for dask input for shortwave with clouds solver

### DIFF
--- a/pyrte_rrtmgp/tests/test_cld_sw_solver.py
+++ b/pyrte_rrtmgp/tests/test_cld_sw_solver.py
@@ -92,3 +92,72 @@ def test_sw_solver_with_clouds() -> None:
                       ref_data["sw_flux_up"].T, atol=1e-7).all()
     assert np.isclose(fluxes["sw_flux_down"],
                       ref_data["sw_flux_dn"].T, atol=1e-7).all()
+
+
+def test_sw_solver_with_clouds_dask() -> None:
+    # Set up dimensions
+    ncol = 24
+    nlay = 72
+
+    # Create atmospheric profiles and gas concentrations
+    atmosphere = compute_profiles(300, ncol, nlay)
+
+    # Add other gas values
+    gas_values = {
+        "co2": 348e-6,
+        "ch4": 1650e-9,
+        "n2o": 306e-9,
+        "n2": 0.7808,
+        "o2": 0.2095,
+        "co": 0.0,
+    }
+
+    for gas_name, value in gas_values.items():
+        atmosphere[gas_name] = xr.DataArray(
+            value,
+            dims=["site", "layer"],
+            coords={"site": range(ncol), "layer": range(nlay)},
+        )
+
+    # Load cloud optics data
+    cloud_optics_sw = rrtmgp_cloud_optics.load_cloud_optics(
+        cloud_optics_file=CloudOpticsFiles.SW_BND
+    )
+
+    # Calculate cloud properties and merge into the atmosphere dataset
+    cloud_properties = compute_clouds(
+        cloud_optics_sw, atmosphere["pres_layer"], atmosphere["temp_layer"]
+    )
+    atmosphere = atmosphere.merge(cloud_properties)
+    atmosphere = atmosphere.chunk({})
+
+    # Calculate cloud optical properties
+    clouds_optical_props = cloud_optics_sw.compute_cloud_optics(atmosphere)
+
+    # Load gas optics and add SW-specific properties
+    gas_optics_sw = rrtmgp_gas_optics.load_gas_optics(
+        gas_optics_file=GasOpticsFiles.SW_G224
+    )
+
+    # Calculate gas optical properties
+    optical_props = gas_optics_sw.compute_gas_optics(
+        atmosphere,
+        problem_type=OpticsProblemTypes.TWO_STREAM,
+        add_to_input=False
+    )
+
+    # Add SW-specific surface and angle properties
+    optical_props["surface_albedo_direct"] = 0.06
+    optical_props["surface_albedo_diffuse"] = 0.06
+    optical_props["mu0"] = 0.86
+
+    fluxes = rte_solve(clouds_optical_props.add_to(optical_props, delta_scale=True),
+                       add_to_input=False)
+    assert fluxes is not None
+
+    # Load reference data and verify results
+    ref_data = load_rrtmgp_file(AllSkyExampleFiles.SW_NO_AEROSOL)
+    assert np.isclose(fluxes["sw_flux_up"],
+                      ref_data["sw_flux_up"].T, atol=1e-7).all()
+    assert np.isclose(fluxes["sw_flux_down"],
+                      ref_data["sw_flux_dn"].T, atol=1e-7).all()


### PR DESCRIPTION
fixes #184 

@sehnem I duplicated the existing `sw_with_clouds` test and chunked the atmosphere.

Currently the test raises the following exception which seems related to :
```python
RuntimeWarning: invalid value encountered in divide
```

I believe it is related to the transpose in `compute_cloud_optics` L304 which raise then error when `.values` is called in the next line:

https://github.com/earth-system-radiation/pyRTE-RRTMGP/blob/main/pyrte_rrtmgp/rrtmgp_cloud_optics.py#L304-L305

@sehnem can you run / enhance / make pass the following test:

```bash
git pull
git checkout fixes-184-add-dask-test-for-shortwave-with-clouds-solver
pytest pyrte_rrtmgp/tests -k test_sw_solver_with_clouds_dask
```
