### PR TITLE
Update list of notebooks in documentation

### DIFF
--- a/docs/source/tutorials/tutorials.md
+++ b/docs/source/tutorials/tutorials.md
@@ -5,9 +5,10 @@ The pyRTE-RRTMGP repository contains a number of tutorials in the form of  [Jupy
 
 Currently, the following tutorials are available in directory `examples/`:
 
+* `pyRTE-quick-start.ipynb`: A quick start guide to using pyRTE-RRTMGP.
 * `sw_example.ipynb`: How to use pyRTE-RRTMGP to compute clear-sky shortwave fluxes.
 * `lw_example.ipynb`: How to use pyRTE-RRTMGP to compute clear-sky longwave fluxes.
-* `dask_example.ipynb`: How to use pyRTE-RRTMGP with [Dask](https://docs.dask.org/en/stable/) to compute clear-sky fluxes with parallel computing (the example is trivally small).
+* `lw_dask_example.ipynb`: How to use pyRTE-RRTMGP with [Dask](https://docs.dask.org/en/stable/) to compute clear-sky fluxes with parallel computing (the example is trivally small).
 * `all_sky_example.ipynb`: How to use pyRTE-RRTMGP to compute both longwave and shortwave fluxes for an idealized all-sky (gases and clouds) scenario.
 * `dyamond_clouds/example.ipynb`: Using a very large (global 3-km) snapshot from the [NASA/GMAO contribution to the DYAMOND 2 project](https://gmao.gsfc.nasa.gov/global_mesoscale/dyamond_phaseII/data_access/) together with Dask to compute cloud optical properties.
 


### PR DESCRIPTION
When I was checking some notebooks, I noticed that our list of notebooks in the docs is slightly outdated. This PR updates the list of available notebooks to include the quick start guide and update the Dask example filename.