### PR TITLE
Add CLI entry to run all .py files in top-level of ./examples/

### DIFF
--- a/.github/workflows/run-example-notebooks.yml
+++ b/.github/workflows/run-example-notebooks.yml
@@ -63,4 +63,4 @@ jobs:
         run: pyrte_rrtmgp run_tests
 
       - name: Run notebooks
-        run: for t in examples/*.py; do python $t; done
+        run: pyrte_rrtmgp run_examples

--- a/pyrte_rrtmgp/cli.py
+++ b/pyrte_rrtmgp/cli.py
@@ -22,8 +22,6 @@ def run_tests() -> None:
                 sys.executable,
                 "-m",
                 "pytest",
-                "--cov=pyrte_rrtmgp",
-                "--cov-report=term-missing:skip-covered",
                 tests_path,
             ],
             check=True,
@@ -32,7 +30,7 @@ def run_tests() -> None:
             text=True,
         )
         print(result.stdout)
-        print("All tests passed successfully.")
+        print("Tests passed.")
     except subprocess.CalledProcessError as e:
         print("Tests failed!")
         print(e.stdout)
@@ -74,6 +72,38 @@ def run_code_coverage() -> None:
         sys.exit(e.returncode)
 
 
+def run_examples() -> None:
+    """Run example notebooks."""
+    package_root = os.path.dirname(os.path.abspath(__file__))
+    print(package_root)
+    notebooks_path = os.path.join(package_root, "../examples")
+
+    if not os.path.exists(notebooks_path):
+        print(f"Error: Examples directory '{notebooks_path}' does not exist.")
+        sys.exit(1)
+
+    for f in [nb for nb in os.listdir(notebooks_path) if nb.endswith("py")]:
+        try:
+            print("Running examples...")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    os.path.join(notebooks_path, f),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            print(result.stdout)
+            print("... succeded.")
+        except subprocess.CalledProcessError as e:
+            print("... failed!")
+            print(e.stdout)
+            print(e.stderr)
+            sys.exit(e.returncode)
+
+
 def main() -> None:
     """Run the pyRTE-RRTMGP command line interface."""
     parser = argparse.ArgumentParser(description="pyRTE-RRTMGP command line interface")
@@ -93,6 +123,12 @@ def main() -> None:
         help="Run code coverage using pytest",
     )
     run_code_coverage_parser.set_defaults(func=run_code_coverage)
+
+    run_examples_parser = subparsers.add_parser(
+        "run_examples",
+        help="Run examples",
+    )
+    run_examples_parser.set_defaults(func=run_examples)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Also removes code coverage from `run_tests` (it was identical to `run_code_coverage`)

Supersedes #190. Will close #163 in favor of `pyrte_rrtmgp run_tests|run_code_coverage|run_examples` 