### PR TITLE
Initial data validation for gas optics

### DIFF
--- a/examples/lw_dask_example.py
+++ b/examples/lw_dask_example.py
@@ -54,6 +54,7 @@
 
 # %%
 import numpy as np
+import xarray as xr
 from dask.diagnostics import ProgressBar
 
 from pyrte_rrtmgp import rrtmgp_gas_optics
@@ -80,6 +81,21 @@ gas_optics_lw = rrtmgp_gas_optics.load_gas_optics(
     gas_optics_file=GasOpticsFiles.LW_G256
 )
 atmosphere = load_example_file(RFMIP_FILES.ATMOSPHERE).chunk({"expt": 3})
+
+
+# %% [markdown]
+# Level pressures need to be >= 0 but the Fortran reference results
+#   were produced using a minimum level pressure matching the minimum 
+#   pressure at which the gas optics tables are calculated, so we 
+#   need to match that minimum pressure to get the same answers 
+
+
+# %%
+atmosphere["pres_level"] = xr.where(
+    atmosphere["pres_level"] < gas_optics_lw.compute_gas_optics.press_min,
+    gas_optics_lw.compute_gas_optics.press_min,
+    atmosphere["pres_level"],
+)
 
 # %% [markdown]
 # ## Computing Gas Optics

--- a/examples/lw_example.py
+++ b/examples/lw_example.py
@@ -52,6 +52,7 @@
 
 # %%
 import numpy as np
+import xarray as xr
 
 from pyrte_rrtmgp import rrtmgp_gas_optics
 from pyrte_rrtmgp.data_types import (
@@ -75,6 +76,21 @@ gas_optics_lw = rrtmgp_gas_optics.load_gas_optics(
     gas_optics_file=GasOpticsFiles.LW_G256
 )
 atmosphere = load_example_file(RFMIP_FILES.ATMOSPHERE)
+
+
+# %% [markdown]
+# Level pressures need to be >= 0 but the Fortran reference results
+#   were produced using a minimum level pressure matching the minimum 
+#   pressure at which the gas optics tables are calculated, so we 
+#   need to match that minimum pressure to get the same answers 
+
+
+# %%
+atmosphere["pres_level"] = xr.where(
+    atmosphere["pres_level"] < gas_optics_lw.compute_gas_optics.press_min,
+    gas_optics_lw.compute_gas_optics.press_min,
+    atmosphere["pres_level"],
+)
 
 # %% [markdown]
 # ## Computing Gas Optics

--- a/examples/sw_example.py
+++ b/examples/sw_example.py
@@ -53,6 +53,7 @@
 
 # %%
 import numpy as np
+import xarray as xr
 
 from pyrte_rrtmgp import rrtmgp_gas_optics
 from pyrte_rrtmgp.data_types import (
@@ -76,6 +77,20 @@ gas_optics_sw = rrtmgp_gas_optics.load_gas_optics(
     gas_optics_file=GasOpticsFiles.SW_G224
 )
 atmosphere = load_example_file(RFMIP_FILES.ATMOSPHERE)
+
+# %% [markdown]
+# Level pressures need to be >= 0 but the Fortran reference results
+#   were produced using a minimum level pressure matching the minimum 
+#   pressure at which the gas optics tables are calculated, so we 
+#   need to match that minimum pressure to get the same answers 
+
+
+# %%
+atmosphere["pres_level"] = xr.where(
+    atmosphere["pres_level"] < gas_optics_sw.compute_gas_optics.press_min,
+    gas_optics_sw.compute_gas_optics.press_min,
+    atmosphere["pres_level"],
+)
 
 # %% [markdown]
 # # Computing Gas Optics

--- a/pyrte_rrtmgp/rrtmgp_gas_optics.py
+++ b/pyrte_rrtmgp/rrtmgp_gas_optics.py
@@ -801,12 +801,12 @@ class BaseGasOpticsAccessor:
         #   level pressure differences > 0
         #
         if (
-            atmosphere[pres_layer_var] < (self.press_min + sys.float_info.epsilon)
+            atmosphere[pres_layer_var] < self.press_min + sys.float_info.epsilon
         ).any() or (
-            atmosphere[pres_layer_var] > (self.press_max - sys.float_info.epsilon)
+            atmosphere[pres_layer_var] > self.press_max - sys.float_info.epsilon
         ).any():
-            print("I object")
             raise ValueError("Layer pressures outside valid range")
+
         temp_layer_var = atmosphere.mapping.get_var("temp_layer")
         if (
             atmosphere[temp_layer_var] < self.temp_min + sys.float_info.epsilon
@@ -814,6 +814,10 @@ class BaseGasOpticsAccessor:
             atmosphere[temp_layer_var] > self.temp_max - sys.float_info.epsilon
         ).any():
             raise ValueError("Layer temperatures outside valid range")
+
+        temp_level_var = atmosphere.mapping.get_var("temp_level")
+        if (atmosphere[temp_level_var] < 0).any():
+            raise ValueError("Level pressures less than 0")
 
         gas_interpolation_data = self.interpolate(atmosphere, gas_mapping)
         problem = self.compute_problem(atmosphere, gas_interpolation_data)

--- a/pyrte_rrtmgp/rrtmgp_gas_optics.py
+++ b/pyrte_rrtmgp/rrtmgp_gas_optics.py
@@ -134,32 +134,27 @@ class BaseGasOpticsAccessor:
         # Set the gas names as coordinate in the dataset
         self._dataset.coords["absorber_ext"] = np.array(("dry_air",) + self._gas_names)
 
-    def _initialize_pressure_levels(
-        self, atmosphere: xr.Dataset, inplace: bool = True
-    ) -> xr.Dataset | None:
-        """Initialize pressure levels with minimum pressure adjustment.
+    # The following four properties return scalars as per
+    #   https://stackoverflow.com/questions/78697726/systematically-turn-numpy-1d-array-of-size-1-to-scalar
+    @property
+    def press_min(self) -> np.float64:
+        """Minimum layer pressure for which gas optics data is valid."""
+        return self._dataset["press_ref"].min().values.squeeze()[()]
 
-        Args:
-            atmosphere: Dataset containing atmospheric conditions
-            inplace: Whether to modify atmosphere in-place or return a copy
+    @property
+    def press_max(self) -> np.float64:
+        """Minimum layer pressure for which gas optics data is valid."""
+        return self._dataset["press_ref"].max().values.squeeze()[()]
 
-        Returns:
-            Modified atmosphere dataset if inplace=False, otherwise None
-        """
-        pres_level_var = atmosphere.mapping.get_var("pres_level")
-        min_press = self._dataset["press_ref"].min() + sys.float_info.epsilon
+    @property
+    def temp_min(self) -> np.float64:
+        """Minimum layer temperature for which gas optics data is valid."""
+        return self._dataset.temp_ref.min().values.squeeze()[()]
 
-        # Replace values smaller than min_press with min_press at min_index
-        atmosphere[pres_level_var] = xr.where(
-            atmosphere[pres_level_var] < min_press,
-            min_press,
-            atmosphere[pres_level_var],
-        )
-
-        if not inplace:
-            return atmosphere
-
-        return None
+    @property
+    def temp_max(self) -> np.float64:
+        """Minimum layer temperature for which gas optics data is valid."""
+        return self._dataset.temp_ref.max().values.squeeze()[()]
 
     @property
     def _selected_gas_names(self) -> list[str]:
@@ -801,8 +796,24 @@ class BaseGasOpticsAccessor:
             < atmosphere[pres_layer_var].values[0, -1]
         )
 
-        # Modify pressure levels to avoid division by zero, runs inplace
-        self._initialize_pressure_levels(atmosphere)
+        # Input data validation
+        #   layer temperatures and pressures within temp_ref, press_ref
+        #   level pressure differences > 0
+        #
+        if (
+            atmosphere[pres_layer_var] < (self.press_min + sys.float_info.epsilon)
+        ).any() or (
+            atmosphere[pres_layer_var] > (self.press_max - sys.float_info.epsilon)
+        ).any():
+            print("I object")
+            raise ValueError("Layer pressures outside valid range")
+        temp_layer_var = atmosphere.mapping.get_var("temp_layer")
+        if (
+            atmosphere[temp_layer_var] < self.temp_min + sys.float_info.epsilon
+        ).any() or (
+            atmosphere[temp_layer_var] > self.temp_max - sys.float_info.epsilon
+        ).any():
+            raise ValueError("Layer temperatures outside valid range")
 
         gas_interpolation_data = self.interpolate(atmosphere, gas_mapping)
         problem = self.compute_problem(atmosphere, gas_interpolation_data)

--- a/pyrte_rrtmgp/tests/test_data_validation.py
+++ b/pyrte_rrtmgp/tests/test_data_validation.py
@@ -26,6 +26,11 @@ def _load_problem_dataset(gas_mapping: Optional[Dict[str, str]],
     )
 
     atmosphere: xr.Dataset = load_example_file(RFMIP_FILES.ATMOSPHERE)
+    atmosphere["pres_level"] = xr.where(
+        atmosphere["pres_level"] < gas_optics_lw.compute_gas_optics.press_min,
+        gas_optics_lw.compute_gas_optics.press_min,
+        atmosphere["pres_level"],
+    )
 
     if use_dask:
         atmosphere = atmosphere.chunk({"expt": 3})

--- a/pyrte_rrtmgp/tests/test_rfmip_clear_sky_lw.py
+++ b/pyrte_rrtmgp/tests/test_rfmip_clear_sky_lw.py
@@ -28,6 +28,12 @@ def test_rfmip_clr_sky_lw() -> None:
     atmosphere = load_example_file(RFMIP_FILES.ATMOSPHERE)
     atmosphere = atmosphere.sel(expt=0)  # only one experiment
 
+    atmosphere["pres_level"] = xr.where(
+        atmosphere["pres_level"] < gas_optics_lw.compute_gas_optics.press_min,
+        gas_optics_lw.compute_gas_optics.press_min,
+        atmosphere["pres_level"],
+    )
+
     # Compute gas optics for the atmosphere
     gas_optics_lw.compute_gas_optics(
         atmosphere, problem_type=OpticsProblemTypes.ABSORPTION,
@@ -60,6 +66,11 @@ def test_rfmip_clr_sky_lw_dask() -> None:
     # Load atmosphere data
     atmosphere = load_example_file(RFMIP_FILES.ATMOSPHERE)
     atmosphere = atmosphere.chunk({"expt": 3})
+    atmosphere["pres_level"] = xr.where(
+        atmosphere["pres_level"] < gas_optics_lw.compute_gas_optics.press_min,
+        gas_optics_lw.compute_gas_optics.press_min,
+        atmosphere["pres_level"],
+    )
 
     assert isinstance(atmosphere, xr.Dataset)
     assert isinstance(atmosphere["lon"].data, da.Array)

--- a/pyrte_rrtmgp/tests/test_rfmip_clear_sky_sw.py
+++ b/pyrte_rrtmgp/tests/test_rfmip_clear_sky_sw.py
@@ -1,4 +1,5 @@
 import numpy as np
+import xarray as xr
 
 from pyrte_rrtmgp.data_types import OpticsProblemTypes
 from pyrte_rrtmgp.rrtmgp_gas_optics import GasOpticsFiles, load_gas_optics
@@ -17,6 +18,11 @@ def test_rfmip_clr_sky_sw() -> None:
     # Load atmosphere data
     atmosphere = load_example_file(RFMIP_FILES.ATMOSPHERE)
     atmosphere = atmosphere.sel(expt=0)  # only one experiment
+    atmosphere["pres_level"] = xr.where(
+        atmosphere["pres_level"] < gas_optics_sw.compute_gas_optics.press_min,
+        gas_optics_sw.compute_gas_optics.press_min,
+        atmosphere["pres_level"],
+    )
 
     # Compute gas optics for the atmosphere
     gas_optics_sw.compute_gas_optics(
@@ -49,6 +55,11 @@ def test_rfmip_clr_sky_sw_dask() -> None:
     # Load atmosphere data
     atmosphere = load_example_file(RFMIP_FILES.ATMOSPHERE)
     atmosphere = atmosphere.chunk({"expt": 3})
+    atmosphere["pres_level"] = xr.where(
+        atmosphere["pres_level"] < gas_optics_sw.compute_gas_optics.press_min,
+        gas_optics_sw.compute_gas_optics.press_min,
+        atmosphere["pres_level"],
+    )
 
     # Compute gas optics for the atmosphere
     gas_optics_sw.compute_gas_optics(


### PR DESCRIPTION
Raises an exception if layer values of temperature and pressure are outside the  range of gas optics data. 

Modifies RFMIP examples to set a floor on level pressures 

Addresses #158 , might supersede #169