### PR TITLE
Restrict pybind11 version to < 3.0.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   host:
     - numpy >=1.21.0
     - pip
-    - pybind11 >=2.10.0
+    - pybind11 >=2.10.0,<3.0.0
     - python
     - rte_rrtmgp ==1.9.1
     - scikit-build-core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
 pyrte_rrtmgp = "pyrte_rrtmgp.cli:main"
 
 [build-system]
-requires = ["scikit-build-core>=0.3.3", "pybind11<3.0.0"]
+requires = ["scikit-build-core>=0.3.3", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
 pyrte_rrtmgp = "pyrte_rrtmgp.cli:main"
 
 [build-system]
-requires = ["scikit-build-core>=0.3.3", "pybind11"]
+requires = ["scikit-build-core>=0.3.3", "pybind11<3.0.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
... because version 3.0.0 breaks scikit-build on MacOS Github runners, so the CI doesn't run. 