### PR TITLE
Introspection functions for gas optics

### DIFF
--- a/docs/source/explanation/usage.md
+++ b/docs/source/explanation/usage.md
@@ -62,27 +62,27 @@ cloud_optics_lw = rrtmgp_cloud_optics.load_cloud_optics(
 
 ### 3. Define the gas optics atmosphere
 
-The atmosphere file defines the gas concentrations for each layer of the atmosphere in mole fractions. The supported gases are:
+The atmosphere file defines the gas concentrations for each layer of the atmosphere in mole fractions. Gases
+are specified in terms of their (lowercase) chemical formula, with `cfcX` used for chlorofluorocarbon-X and
+`hfcX` for hydrofluorocarbon-X. Supported gases, i.e. those that will influence the calculation of optical properties,
+are available using the `available_gases` property of the gas optics, i.e.
+```python
+gas_optics = rrtmgp_gas_optics.load_gas_optics(
+    gas_optics_file=GasOpticsFiles.LW_G128
+).available_gases
 
-* `h2o`: Water vapor
-* `co2`: Carbon dioxide
-* `o3`: Ozone
-* `n2o`: Nitrous oxide
-* `co`: Carbon monoxide
-* `ch4`: Methane
-* `o2`: Oxygen
-* `n2`: Nitrogen
-* `ccl4`: Carbon tetrachloride
-* `cfc11`: Chlorofluorocarbon-11
-* `cfc12`: Chlorofluorocarbon-12
-* `cfc22`: Chlorofluorocarbon-22
-* `hfc143a`: Hydrofluorocarbon-143a
-* `hfc125`: Hydrofluorocarbon-125
-* `hfc23`: Hydrofluorocarbon-23
-* `hfc32`: Hydrofluorocarbon-32
-* `hfc134a`: Hydrofluorocarbon-134a
-* `cf4`: Carbon tetrafluoride
-* `no2`: Nitrogen dioxide
+gas_optics.required_gases
+```
+
+
+Concentrations of some gases are required, those these can vary between the shortwave and longwave gas optics.
+```python
+gas_optics = rrtmgp_gas_optics.load_gas_optics(
+    gas_optics_file=GasOpticsFiles.LW_G128
+)
+
+gas_optics.required_gases
+```
 
 You can use any of the alternative names in your dataset, and use a mapping dictionary to map them to the correct gas. See {data}`~pyrte_rrtmgp.config.DEFAULT_GAS_MAPPING` for the default mapping.
 

--- a/pyrte_rrtmgp/rrtmgp_gas_optics.py
+++ b/pyrte_rrtmgp/rrtmgp_gas_optics.py
@@ -157,6 +157,18 @@ class BaseGasOpticsAccessor:
         return self._dataset.temp_ref.max().values.squeeze()[()]
 
     @property
+    def required_gases(self) -> set[str]:
+        """Gases for which the concentration must be specified."""
+        uniq_key_species = np.unique(self._dataset.key_species.values)
+        required_gases = self._dataset.gas_names.values[uniq_key_species]
+        return set([g.decode().strip() for g in required_gases])
+
+    @property
+    def available_gases(self) -> set[str]:
+        """Gases whose concentrations influence optical depth."""
+        return set(self._dataset.gas_names)
+
+    @property
     def _selected_gas_names(self) -> list[str]:
         """List of selected gas names."""
         return list(self._gas_names)
@@ -751,11 +763,7 @@ class BaseGasOpticsAccessor:
         # layer and level dimensions should be present, nlay = nlev -1
 
         # Some gas concentrations are required. Are they present?
-        uniq_key_species = np.unique(self._dataset.key_species.values)
-        required_gases = self._dataset.gas_names.values[uniq_key_species]
-        required_gases = set([g.decode().strip() for g in required_gases])
-
-        gas_validation_set = set(required_gases) - set(gas_mapping.keys())
+        gas_validation_set = self.required_gases - set(gas_mapping.keys())
         if len(gas_validation_set) > 0:
             raise ValueError(
                 f"Missing required gases in gas mapping: {gas_validation_set}"

--- a/pyrte_rrtmgp/rrtmgp_gas_optics.py
+++ b/pyrte_rrtmgp/rrtmgp_gas_optics.py
@@ -166,7 +166,7 @@ class BaseGasOpticsAccessor:
     @property
     def available_gases(self) -> set[str]:
         """Gases whose concentrations influence optical depth."""
-        return set(self._dataset.gas_names)
+        return set([g.decode().strip() for g in self._dataset.gas_names.values])
 
     @property
     def _selected_gas_names(self) -> list[str]:


### PR DESCRIPTION
Add properties `required_gases` and `available_gases` to the gas optics class. The functions return the chemical formulae of those gases required for computing optical properties, and those that can be included in the calculation, respectively. 