### PR TITLE
Revise package build for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-23.11"
+    python: "miniforge3"
   apt_packages:
     - build-essential
     - ninja-build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,16 +13,6 @@ build:
   apt_packages:
     - build-essential
     - ninja-build
-  jobs:
-    pre_build:
-      # build and install the package with conda
-      - conda list  # Debug: List the installed packages
-      - conda config --add channels conda-forge
-      - conda info  # Debug: List the conda configuration
-      - conda build conda.recipe
-      - ls $(conda info --base)/conda-bld/linux-64  # Debug: List the contents of the build directory
-      - conda index $(conda info --base)/conda-bld  # Index the correct build directory
-      - conda install -c file://$(conda info --base)/conda-bld/linux-64 pyrte_rrtmgp
 
 conda:
   environment: docs/environment-docs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "miniforge3"
+    python: "mambaforge-latest"
   apt_packages:
     - build-essential
     - ninja-build

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -13,4 +13,4 @@ dependencies:
   - myst-parser==2.0.*
   - pip
   - pip:
-    - -e .
+    - -e ..

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -1,18 +1,16 @@
 name: pyrte_rrtmgp_docs
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.12
   # when updating the tested Python versions, please also update README.md,
   # the conda.recipe/meta.yaml file, pyproject.toml, and the conda.yml file
   # for the GitHub Actions workflow
   - rte_rrtmgp
-  - conda-build
-  - conda-verify
+  - xarray
+  - pandas
+  - sphinx-rtd-theme==2.0.*
+  - myst-parser==2.0.*
   - pip
   - pip:
-    - sphinx-rtd-theme==2.0.*
-    - myst-parser==2.0.*
-    - xarray
-    - pandas
+    - -e .


### PR DESCRIPTION
Documentation on how to configure the readthedocs is thin on the ground, but building the package with `conda-build` before parsing it for documentation seems heavy. 