### PR TITLE
LW solver uses approximate rescaling to account for scattering

### DIFF
--- a/examples/all_sky_example.md
+++ b/examples/all_sky_example.md
@@ -5,7 +5,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.17.2
+      jupytext_version: 1.19.1
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -185,12 +185,11 @@ assert np.isclose(
 print("All-sky longwave calculations validated successfully")
 ```
 
-### Effects of LW Scattering on Fluxes
+### Scattering by clouds can be included in longwave calculations
+
+Here's an example demonstrating scattering by clouds. See the [pull request](https://github.com/earth-system-radiation/pyRTE-RRTMGP/pull/286) for a figure. 
 
 ```python
-import matplotlib.pyplot as plt
-
-### run pyRTE-RRTMGP including LW scattering
 clouds_optical_props_scattering = cloud_optics_lw.compute(
     atmosphere,
     problem_type = rte.OpticsTypes.TWO_STREAM,
@@ -208,78 +207,7 @@ optical_props = optical_props.assign({
 
 clouds_optical_props_scattering.rte.add_to(optical_props)
 
-# compute longwave fluxes
 fluxes_scattering = optical_props.rte.solve(add_to_input=False)
-```
-
-```python
-### plot figures
-
-idx = 2
-
-fig, axes = plt.subplots(2, 2, figsize = (8, 5), sharey = True)
-axes[0, 0].plot(ref_data["lw_flux_up"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
-axes[0, 0].plot(fluxes["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
-axes[0, 0].plot(fluxes_scattering["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
-
-axes[0, 0].set_ylim([1000, 1])
-axes[0, 0].set_yscale('log')
-axes[0, 0].spines[['right', 'top']].set_visible(False)
-axes[0, 0].set_ylabel("Clear-sky atmosphere\npressure (hPa)")
-
-axes[0, 1].plot(ref_data["lw_flux_dn"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
-axes[0, 1].plot(fluxes["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
-axes[0, 1].plot(fluxes_scattering["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
-
-axes[0, 1].spines[['right', 'top']].set_visible(False)
-
-idx = 3
-axes[1, 0].plot(ref_data["lw_flux_up"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
-axes[1, 0].plot(fluxes["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
-axes[1, 0].plot(fluxes_scattering["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
-
-axes[1, 0].set_ylim([1000, 1])
-axes[1, 0].set_yscale('log')
-axes[1, 0].spines[['right', 'top']].set_visible(False)
-axes[1, 0].set_xlabel("LW Flux Up (W/m$^2$)")
-axes[1, 0].set_ylabel("Low and High Cloud\npressure (hPa)")
-
-axes[1, 1].plot(ref_data["lw_flux_dn"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
-axes[1, 1].plot(fluxes["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
-axes[1, 1].plot(fluxes_scattering["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
-
-axes[1, 1].spines[['right', 'top']].set_visible(False)
-axes[1, 1].set_xlabel("LW Flux Down (W/m$^2$)")
-
-
-axes[0, 0].legend(frameon = False)
-
-plt.show()
-
-fig, axes = plt.subplots(1, 2, figsize = (8, 2.5), sharey = True)
-
-idx = 3
-axes[0].plot(ref_data["lw_flux_up"].isel(col = idx).data - fluxes_scattering["lw_flux_up"].isel(column = idx).data, ref_data["p_lev"].isel(col = idx)/100, label = 'Ref. $-$ lw. scatt.')
-#axes[0].plot(fluxes["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
-#axes[0].plot(f, ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
-
-axes[0].set_ylim([1000, 1])
-axes[0].set_yscale('log')
-axes[0].spines[['right', 'top']].set_visible(False)
-axes[0].set_xlabel("$\\Delta$ LW Flux Up (W/m$^2$)")
-axes[0].set_ylabel("Low and High Cloud\npressure (hPa)")
-
-axes[1].plot(ref_data["lw_flux_dn"].isel(col = idx).data - fluxes_scattering["lw_flux_down"].isel(column = idx).data, ref_data["p_lev"].isel(col = idx)/100, label = 'Ref. $-$ lw. scatt.')
-#axes[1].plot(fluxes["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
-#axes[1].plot(, ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
-
-axes[1].spines[['right', 'top']].set_visible(False)
-axes[1].set_xlabel("$\\Delta$ LW Flux Down (W/m$^2$)")
-
-axes[0].legend(frameon = False)
-
-plt.show()
-
 ```
 
 # Shortwave calculations

--- a/examples/all_sky_example.md
+++ b/examples/all_sky_example.md
@@ -185,6 +185,103 @@ assert np.isclose(
 print("All-sky longwave calculations validated successfully")
 ```
 
+### Effects of LW Scattering on Fluxes
+
+```python
+import matplotlib.pyplot as plt
+
+### run pyRTE-RRTMGP including LW scattering
+clouds_optical_props_scattering = cloud_optics_lw.compute(
+    atmosphere,
+    problem_type = rte.OpticsTypes.TWO_STREAM,
+)
+
+# identify cloud
+cloud_mask = ((atmosphere.iwp > 0) | (atmosphere.lwp > 0)).data.T[:, None, :] * np.ones_like(optical_props.tau)
+
+## add cloud optical properties for longwave scattering
+optical_props = optical_props.assign({
+    "ssa" : (("layer", "gpt", "column"), 0.6 * cloud_mask),
+    "g" : (("layer", "gpt", "column"), 0.8 * cloud_mask)
+})
+
+
+clouds_optical_props_scattering.rte.add_to(optical_props)
+
+# compute longwave fluxes
+fluxes_scattering = optical_props.rte.solve(add_to_input=False)
+```
+
+```python
+### plot figures
+
+idx = 2
+
+fig, axes = plt.subplots(2, 2, figsize = (8, 5), sharey = True)
+axes[0, 0].plot(ref_data["lw_flux_up"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
+axes[0, 0].plot(fluxes["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
+axes[0, 0].plot(fluxes_scattering["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
+
+axes[0, 0].set_ylim([1000, 1])
+axes[0, 0].set_yscale('log')
+axes[0, 0].spines[['right', 'top']].set_visible(False)
+axes[0, 0].set_ylabel("Clear-sky atmosphere\npressure (hPa)")
+
+axes[0, 1].plot(ref_data["lw_flux_dn"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
+axes[0, 1].plot(fluxes["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
+axes[0, 1].plot(fluxes_scattering["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
+
+axes[0, 1].spines[['right', 'top']].set_visible(False)
+
+idx = 3
+axes[1, 0].plot(ref_data["lw_flux_up"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
+axes[1, 0].plot(fluxes["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
+axes[1, 0].plot(fluxes_scattering["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
+
+axes[1, 0].set_ylim([1000, 1])
+axes[1, 0].set_yscale('log')
+axes[1, 0].spines[['right', 'top']].set_visible(False)
+axes[1, 0].set_xlabel("LW Flux Up (W/m$^2$)")
+axes[1, 0].set_ylabel("Low and High Cloud\npressure (hPa)")
+
+axes[1, 1].plot(ref_data["lw_flux_dn"].isel(col = idx), ref_data["p_lev"].isel(col = idx)/100, label = 'REFERENCE')
+axes[1, 1].plot(fluxes["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
+axes[1, 1].plot(fluxes_scattering["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
+
+axes[1, 1].spines[['right', 'top']].set_visible(False)
+axes[1, 1].set_xlabel("LW Flux Down (W/m$^2$)")
+
+
+axes[0, 0].legend(frameon = False)
+
+plt.show()
+
+fig, axes = plt.subplots(1, 2, figsize = (8, 2.5), sharey = True)
+
+idx = 3
+axes[0].plot(ref_data["lw_flux_up"].isel(col = idx).data - fluxes_scattering["lw_flux_up"].isel(column = idx).data, ref_data["p_lev"].isel(col = idx)/100, label = 'Ref. $-$ lw. scatt.')
+#axes[0].plot(fluxes["lw_flux_up"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
+#axes[0].plot(f, ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
+
+axes[0].set_ylim([1000, 1])
+axes[0].set_yscale('log')
+axes[0].spines[['right', 'top']].set_visible(False)
+axes[0].set_xlabel("$\\Delta$ LW Flux Up (W/m$^2$)")
+axes[0].set_ylabel("Low and High Cloud\npressure (hPa)")
+
+axes[1].plot(ref_data["lw_flux_dn"].isel(col = idx).data - fluxes_scattering["lw_flux_down"].isel(column = idx).data, ref_data["p_lev"].isel(col = idx)/100, label = 'Ref. $-$ lw. scatt.')
+#axes[1].plot(fluxes["lw_flux_down"].isel(column = idx), ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (no lw. scatt.)")
+#axes[1].plot(, ref_data["p_lev"].isel(col = idx)/100, '--', label = "RRTMGP (lw. scatt.)")
+
+axes[1].spines[['right', 'top']].set_visible(False)
+axes[1].set_xlabel("$\\Delta$ LW Flux Down (W/m$^2$)")
+
+axes[0].legend(frameon = False)
+
+plt.show()
+
+```
+
 # Shortwave calculations
 
 In this example steps are combined where possible

--- a/pyrte_rrtmgp/kernels/rte.py
+++ b/pyrte_rrtmgp/kernels/rte.py
@@ -37,11 +37,11 @@ def lw_solver_noscat(
     sfc_src: npt.NDArray[np.float64],
     sfc_src_jac: npt.NDArray[np.float64],
     inc_flux: npt.NDArray[np.float64],
+    do_rescaling: bool,
     top_at_1: bool = True,
     nmus: int = 1,
     do_broadband: bool = True,
     do_Jacobians: bool = False,
-    do_rescaling: bool = False,
 ) -> Tuple[
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],

--- a/pyrte_rrtmgp/kernels/rte.py
+++ b/pyrte_rrtmgp/kernels/rte.py
@@ -23,7 +23,7 @@ from pyrte_rrtmgp.pyrte_rrtmgp import (
 )
 
 
-def lw_solver_noscat(
+def lw_solver(
     nlay: int,
     ngpt: int,
     ds: npt.NDArray[np.float64],
@@ -37,11 +37,11 @@ def lw_solver_noscat(
     sfc_src: npt.NDArray[np.float64],
     sfc_src_jac: npt.NDArray[np.float64],
     inc_flux: npt.NDArray[np.float64],
-    do_rescaling: bool,
     top_at_1: bool = True,
     nmus: int = 1,
     do_broadband: bool = True,
     do_Jacobians: bool = False,
+    do_rescaling: bool = False,
 ) -> Tuple[
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
@@ -50,8 +50,8 @@ def lw_solver_noscat(
 ]:
     """Perform longwave radiation transfer calculations without scattering.
 
-    This function solves the longwave radiative transfer equation in the absence of
-    scattering, computing fluxes and optionally their Jacobians.
+    This function solves the longwave radiative transfer equation for absorption
+        and emission.
 
     Args:
         nlay: Number of layers

--- a/pyrte_rrtmgp/rte.py
+++ b/pyrte_rrtmgp/rte.py
@@ -173,6 +173,7 @@ class RTEAccessor:
         g: xr.DataArray = (
             problem_ds["g"] if "g" in problem_ds else xr.zeros_like(problem_ds["tau"])
         )
+        do_rescaling: bool = "ssa" in problem_ds and "g" in problem_ds
 
         (
             solver_flux_up_broadband,
@@ -194,6 +195,7 @@ class RTEAccessor:
             problem_ds["surface_source"],
             problem_ds["surface_source_jacobian"],
             incident_flux,
+            do_rescaling,
             kwargs={"do_broadband": True, "top_at_1": top_at_1},
             input_core_dims=[
                 [],  # nlay
@@ -209,6 +211,7 @@ class RTEAccessor:
                 ["gpt"],  # sfc_src
                 ["gpt"],  # sfc_src_jac
                 ["gpt"],  # inc_flux
+                [],  # do_rescaling
             ],
             output_core_dims=[
                 [level_dim],  # solver_flux_up_broadband

--- a/pyrte_rrtmgp/rte.py
+++ b/pyrte_rrtmgp/rte.py
@@ -18,7 +18,7 @@ from pyrte_rrtmgp.kernels.rte import (
     increment_1scalar_by_2stream,
     increment_2stream_by_1scalar,
     increment_2stream_by_2stream,
-    lw_solver_noscat,
+    lw_solver,
     sw_solver_2stream,
 )
 from pyrte_rrtmgp.utils import expand_variable_dims
@@ -181,7 +181,7 @@ class RTEAccessor:
             _,
             _,
         ) = xr.apply_ufunc(
-            lw_solver_noscat,
+            lw_solver,
             problem_ds.sizes[layer_dim],
             problem_ds.sizes["gpt"],
             ds,
@@ -195,8 +195,11 @@ class RTEAccessor:
             problem_ds["surface_source"],
             problem_ds["surface_source_jacobian"],
             incident_flux,
-            do_rescaling,
-            kwargs={"do_broadband": True, "top_at_1": top_at_1},
+            kwargs={
+                "do_broadband": True,
+                "do_rescaling": do_rescaling,
+                "top_at_1": top_at_1,
+            },
             input_core_dims=[
                 [],  # nlay
                 [],  # ngpt
@@ -211,7 +214,6 @@ class RTEAccessor:
                 ["gpt"],  # sfc_src
                 ["gpt"],  # sfc_src_jac
                 ["gpt"],  # inc_flux
-                [],  # do_rescaling
             ],
             output_core_dims=[
                 [level_dim],  # solver_flux_up_broadband


### PR DESCRIPTION
Enables [Tang et al.](https://doi.org/10.1175/JAS-D-18-0014.1) approximation for longwave scattering. (This was present in the Fortran code but not accessible via the Python implementation.) 