### PR TITLE
No explicit pandas dependencies

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -10,11 +10,10 @@ dependencies:
   - pytest
   - rte_rrtmgp
   - dask
-  - pandas<3.0.0
   - typing_extensions
   - pre-commit
   - cmake
   - ninja
   - pip
   - pip:
-    - -e ..
+    - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.11,<3.15"
 dependencies = [
   "numpy>=1.21.1",
   "xarray>=2023.5.0",
-  "pandas<3.0.0",
   "netcdf4>=1.7.2",
   "requests>=2.4.0",
   "pytest>=6.0.0"
@@ -31,7 +30,6 @@ test = [
   "pytest-cov>=3.0",
   "numpy>=1.21.1",
   "xarray>=2023.5.0",
-  "pandas<3.0.0",
   "dask >=2023.5.0",
   "netcdf4>=1.7.2",
   "requests>=2.4.0"

--- a/pyrte_rrtmgp/rrtmgp.py
+++ b/pyrte_rrtmgp/rrtmgp.py
@@ -8,7 +8,6 @@ from typing import Dict, Final, Iterable, cast
 import dask.array as da
 import numpy as np
 import numpy.typing as npt
-import pandas as pd
 import xarray as xr
 
 from pyrte_rrtmgp.config import DEFAULT_GAS_MAPPING
@@ -183,7 +182,12 @@ class BaseGasOptics:
             gas_values.append(values)
 
         gas_da: xr.DataArray = xr.concat(
-            gas_values, dim=pd.Index(gas_name_map.keys(), name="gas"), coords="minimal"
+            gas_values,
+            dim=xr.DataArray(
+                [k for k in gas_name_map.keys()],
+                dims=["gas"],
+            ),
+            coords="minimal",
         )
 
         col_dry = self.get_col_dry(gas_da.sel(gas="h2o"), atmosphere, latitude=None)
@@ -1108,7 +1112,10 @@ class SWGasOptics(BaseGasOptics):
         # Combine upper and lower Rayleigh coefficients
         krayl = xr.concat(
             [self._dataset["rayl_lower"], self._dataset["rayl_upper"]],
-            dim=pd.Index(["lower", "upper"], name="rayl_bound"),
+            dim=xr.DataArray(
+                ["lower", "upper"],
+                dims=["rayl_bound"],
+            ),
         )
 
         layer_dim = gas_interpolation_data.mapping.get_dim("layer")


### PR DESCRIPTION
Replace a pandas index with an xr.DataArray in constructing internal RRTMGP data. Fixes #293 and removes any explicit need for the pandas package. 