### PR TITLE
Don't scale gas concentrations with "units" attribute

### DIFF
--- a/examples/rfmip-clear-sky.md
+++ b/examples/rfmip-clear-sky.md
@@ -90,33 +90,37 @@ atmosphere["pres_level"] = xr.ufuncs.maximum(
 ## Conform to expectations
 
 pyRRTMGP interprets the input `xr.Dataset` by looking for `xr.DataArray`s with specific names. 
-  Those names can be over-ridden via a mapping. 
-  Here we create such a mapping for the gases in the RFMIP dataset. 
-  The names as RRTMGP expects them are the keys in the dictionary; the valus are the names in the RFMIP dataset
+  Gases are specified with their chemical formula (or, for halocarbons, by an abbreviation), and 
+  volume mixing ratios are expected in absolute units, so the RFMIP datasets needs some manipulation. 
 
 
 ```python
-gas_mapping = {
-    "h2o": "water_vapor",
-    "co2": "carbon_dioxide_GM",
-    "o3": "ozone",
-    "n2o": "nitrous_oxide_GM",
-    "co": "carbon_monoxide_GM",
-    "ch4": "methane_GM",
-    "o2": "oxygen_GM",
-    "n2": "nitrogen_GM",
-    "ccl4": "carbon_tetrachloride_GM",
-    "cfc11": "cfc11_GM",
-    "cfc12": "cfc12_GM",
-    "cfc22": "hcfc22_GM",
-    "hfc143a": "hfc143a_GM",
-    "hfc125": "hfc125_GM",
-    "hfc23": "hfc23_GM",
-    "hfc32": "hfc32_GM",
-    "hfc134a": "hfc134a_GM",
-    "cf4": "cf4_GM",
-    "no2": "no2",
+gas_names = {
+    "water_vapor": "h2o",
+    "carbon_dioxide_GM": "co2",
+    "ozone":"o3",
+    "nitrous_oxide_GM": "n2o",
+    "carbon_monoxide_GM": "co",
+    "methane_GM": "ch4",
+    "oxygen_GM": "o2",
+    "nitrogen_GM": "n2",
+    "carbon_tetrachloride_GM": "ccl4",
+    "cfc11_GM": "cfc11",
+    "cfc12_GM": "cfc12",
+    "hcfc22_GM": "cfc22",
+    "hfc143a_GM": "hfc143a",
+    "hfc125_GM": "hfc125",
+    "hfc23_GM": "hfc23",
+    "hfc32_GM": "hfc32",
+    "hfc134a_GM": "hfc134a",
+    "cf4_GM": "cf4",
 }
+
+atmosphere = atmosphere.rename_vars(gas_names)
+for g in gas_names.values(): 
+    if hasattr(atmosphere[g], "units"):
+        atmosphere[g] *= float(atmosphere[g].units)
+        atmosphere[g].assign_attrs({"units":"1"})
 ```
 
 # Compute the spectrally-dependent optical properties 
@@ -129,7 +133,6 @@ For the longwave problem we will make a new dataset with the optical properties
 ```python
 optical_props = gas_optics_lw.compute(
     atmosphere,
-    gas_name_map=gas_mapping,
     add_to_input = False,
 )
 optical_props
@@ -142,7 +145,6 @@ For the shortave problem we will append the optical properties to the original d
 ```python
 gas_optics_sw.compute(
     atmosphere,
-    gas_name_map=gas_mapping,
 )
 atmosphere
 ```
@@ -184,7 +186,8 @@ ref = xr.merge([
 	load_example_file(RFMIP_FILES.REFERENCE_RLD),
 	load_example_file(RFMIP_FILES.REFERENCE_RSU), 
 	load_example_file(RFMIP_FILES.REFERENCE_RSD),
-	]
+	], 
+    compat='equals', 
 )
 ```
 

--- a/pyrte_rrtmgp/rrtmgp.py
+++ b/pyrte_rrtmgp/rrtmgp.py
@@ -171,8 +171,6 @@ class BaseGasOptics:
         for gas_map in gas_name_map.values():
             if gas_map in atmosphere.data_vars:
                 values = atmosphere[gas_map]
-                if hasattr(values, "units"):
-                    values = values * float(values.units)
                 if values.ndim == 0:
                     values = xr.full_like(
                         atmosphere[pres_level_var].isel(level=0), values

--- a/pyrte_rrtmgp/tests/__init__.py
+++ b/pyrte_rrtmgp/tests/__init__.py
@@ -17,7 +17,6 @@ RFMIP_GAS_MAPPING =  {
     "hfc32": "hfc32_GM",
     "hfc134a": "hfc134a_GM",
     "cf4": "cf4_GM",
-    "no2": "no2",
 }
 
 RFMIP_GAS_MAPPING_SMALL =  {

--- a/pyrte_rrtmgp/tests/test_rfmip_clear_sky.py
+++ b/pyrte_rrtmgp/tests/test_rfmip_clear_sky.py
@@ -20,6 +20,25 @@ from pyrte_rrtmgp.tests import (
 from pyrte_rrtmgp import rte
 from pyrte_rrtmgp.rrtmgp import GasOptics
 
+def _load_atmos_data(
+    gas_name_mapping: Optional[dict[str, str]] = None,
+) -> xr.Dataset:
+
+    atmosphere: xr.Dataset = load_example_file(RFMIP_FILES.ATMOSPHERE)
+    if gas_name_mapping is None:
+        gas_name_mapping = RFMIP_GAS_MAPPING
+    #
+    # Gas name maps have keys, values reversed
+    #
+    atmosphere = atmosphere. \
+        rename_vars({v:k for k, v in gas_name_mapping.items()})
+    for g in gas_name_mapping.keys():
+        if hasattr(atmosphere[g], "units"):
+            atmosphere[g] *= float(atmosphere[g].units)
+            atmosphere[g].assign_attrs({"units":"1"})
+
+    return(atmosphere)
+
 def _load_reference_data() -> xr.Dataset:
      return xr.merge([
         load_example_file(RFMIP_FILES.REFERENCE_RLU),
@@ -28,24 +47,20 @@ def _load_reference_data() -> xr.Dataset:
         load_example_file(RFMIP_FILES.REFERENCE_RSD),
         ], compat="equals")
 
-# Ideally we would tell mypy that gas_optics is an xarray accessor...
 def _test_get_fluxes_from_RFMIP_atmospheres(
                  gas_optics: GasOptics,
                  gas_name_mapping: Optional[dict[str, str]] = None,
                  use_dask: bool = False) -> xr.Dataset:
     """Runs RFMIP clear-sky examples to exercise gas optics, solvers, and gas mapping """
+
+    atmosphere = _load_atmos_data(gas_name_mapping)
     # Load atmosphere data
-    atmosphere: xr.Dataset = load_example_file(RFMIP_FILES.ATMOSPHERE)
     if use_dask:
         atmosphere = atmosphere.chunk({"expt": 3})
-
-    if gas_name_mapping is None:
-        gas_name_mapping = RFMIP_GAS_MAPPING
 
     # Compute gas optics for the atmosphere
     gas_optics.compute( # type: ignore
         atmosphere,
-        gas_name_map=gas_name_mapping,
     )
 
     # Solve RTE
@@ -75,7 +90,7 @@ def _test_verify_rfmip_clr_sky(
         )
 
     # Load atmosphere, modify to match
-    atmosphere: xr.Dataset = load_example_file(RFMIP_FILES.ATMOSPHERE)
+    atmosphere = _load_atmos_data()
     if use_dask:
         atmosphere = atmosphere.chunk({"expt": 3})
     atmosphere["pres_level"] = xr.ufuncs.maximum(
@@ -86,7 +101,6 @@ def _test_verify_rfmip_clr_sky(
     # Gas optics
     gas_optics.compute( #type: ignore
         atmosphere,
-        gas_name_map=RFMIP_GAS_MAPPING,
     )
     # Solve RTE
     fluxes: xr.Dataset = atmosphere.rte.solve(add_to_input=False)


### PR DESCRIPTION
In the spirit of asking users to be responsible for input data, `gas_optics_[ls]w()` no longer scales gas concentrations with the "units" attribute. The RFMIP example is updated. The example also shows renames DataArrays on the fly to avoid using the internal `gas_mapping` (#244) 